### PR TITLE
Add Net 7.0 targeting

### DIFF
--- a/src/LiveStreamingServerNet.AdminPanelUI/LiveStreamingServerNet.AdminPanelUI.csproj
+++ b/src/LiveStreamingServerNet.AdminPanelUI/LiveStreamingServerNet.AdminPanelUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/RtmpServerStreamEventListener.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/RtmpServerStreamEventListener.cs
@@ -1,5 +1,6 @@
 ﻿using LiveStreamingServerNet.Flv.Internal.Services.Contracts;
 using LiveStreamingServerNet.Rtmp.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
 
 namespace LiveStreamingServerNet.Flv.Internal.Services
 {

--- a/src/LiveStreamingServerNet.Flv/LiveStreamingServerNet.Flv.csproj
+++ b/src/LiveStreamingServerNet.Flv/LiveStreamingServerNet.Flv.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/LiveStreamingServerNet.Networking/LiveStreamingServerNet.Networking.csproj
+++ b/src/LiveStreamingServerNet.Networking/LiveStreamingServerNet.Networking.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/LiveStreamingServerNet.Networking/Server.cs
+++ b/src/LiveStreamingServerNet.Networking/Server.cs
@@ -69,7 +69,10 @@ namespace LiveStreamingServerNet.Networking
             await Task.WhenAll(_clientTasks.Select(x => x.Value.Task));
 
             foreach (var serverListener in serverListeners)
-                serverListener.TcpListener.Dispose();
+            {
+                // Dispose in Net8.0 calls the stop method but is not available in Net7.0
+                serverListener.TcpListener.Stop();
+            }
 
             await OnServerStoppedAsync();
 

--- a/src/LiveStreamingServerNet.Networking/Server.cs
+++ b/src/LiveStreamingServerNet.Networking/Server.cs
@@ -38,7 +38,10 @@ namespace LiveStreamingServerNet.Networking
 
         public Task RunAsync(ServerEndPoint serverEndPoint, CancellationToken cancellationToken = default)
         {
-            return RunAsync([serverEndPoint], cancellationToken);
+            return RunAsync(new List<ServerEndPoint>
+            {
+                serverEndPoint
+            }, cancellationToken);
         }
 
         public async Task RunAsync(IList<ServerEndPoint> serverEndPoints, CancellationToken cancellationToken = default)

--- a/src/LiveStreamingServerNet.Rtmp/Internal/Extensions/AmfWriterExtensions.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/Extensions/AmfWriterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using mtanksl.ActionMessageFormat;
+using LiveStreamingServerNet.Utilities.Extensions;
 
 namespace LiveStreamingServerNet.Rtmp.Internal.Extensions
 {
@@ -8,7 +9,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Extensions
         {
             var amf0Object = new Amf0Object();
             amf0Object.ClassName = string.Empty;
-            amf0Object.DynamicMembersAndValues = keyValuePairs is Dictionary<string, object?> dict ? dict : keyValuePairs.ToDictionary();
+            amf0Object.DynamicMembersAndValues = keyValuePairs as Dictionary<string, object?> ?? keyValuePairs.ToDictionary();
             amfWriter.WriteAmf0(amf0Object);
         }
 
@@ -16,7 +17,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Extensions
         {
             var amf0Object = new Amf3Object();
             amf0Object.Trait.IsDynamic = true;
-            amf0Object.DynamicMembersAndValues = keyValuePairs is Dictionary<string, object?> dict ? dict : keyValuePairs.ToDictionary();
+            amf0Object.DynamicMembersAndValues = keyValuePairs as Dictionary<string, object?> ?? keyValuePairs.ToDictionary();
             amfWriter.WriteAmf0(amf0Object);
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp/Internal/RtmpConstants.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/RtmpConstants.cs
@@ -2,7 +2,7 @@
 {
     internal static class RtmpConstants
     {
-        public static readonly byte[] ServerVersion = [1, 0, 0, 0];
+        public static readonly byte[] ServerVersion = { 1, 0, 0, 0 };
 
         public const uint DefaultChunkSize = 128;
 

--- a/src/LiveStreamingServerNet.Rtmp/Internal/RtmpEventHandlers/Commands/RtmpConnectCommandHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/RtmpEventHandlers/Commands/RtmpConnectCommandHandler.cs
@@ -69,7 +69,8 @@ namespace LiveStreamingServerNet.Rtmp.Internal.RtmpEventHandlers.Commands
                         { "capabilities", 31 },
                         { "mode", 1 }
                     },
-                parameters: [
+                parameters: new List<object?>
+                {
                     new Dictionary<string, object>
                     {
                         { RtmpArgumentNames.Level, RtmpArgumentValues.Status },
@@ -77,7 +78,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.RtmpEventHandlers.Commands
                         { RtmpArgumentNames.Description, "Connection succeeded." },
                         { RtmpArgumentNames.ObjectEncoding, 0 }
                     }
-                ]
+                }
             );
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp/Internal/RtmpEventHandlers/Commands/RtmpCreateStreamCommandHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/RtmpEventHandlers/Commands/RtmpCreateStreamCommandHandler.cs
@@ -35,7 +35,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.RtmpEventHandlers.Commands
                 commandName: "_result",
                 transactionId: command.TransactionId,
                 commandObject: null,
-                parameters: [clientContext.CreateNewStream()]
+                parameters: new List<object?> { clientContext.CreateNewStream() }
             );
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp/Internal/RtmpServerContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/RtmpServerContext.cs
@@ -1,15 +1,21 @@
 ﻿using LiveStreamingServerNet.Rtmp.Contracts;
-using System.Security.Cryptography;
+using System.Text;
 
 namespace LiveStreamingServerNet.Rtmp.Internal
 {
     internal class RtmpServerContext : IRtmpServerContext
     {
-        public string AuthCode { get; }
+        public string AuthCode { get; } = GenerateRandomHexString(64);
 
-        public RtmpServerContext()
+        private static string GenerateRandomHexString(int length)
         {
-            AuthCode = RandomNumberGenerator.GetHexString(64);
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            var random = new Random();
+            var randomString = new string(Enumerable.Repeat(chars, length)
+                           .Select(s => s[random.Next(s.Length)]).ToArray());
+
+            var randomBytes = Encoding.UTF8.GetBytes(randomString);
+            return BitConverter.ToString(randomBytes).Replace("-", string.Empty);
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp/Internal/Services/Extensions/RtmpCommandMessageSenderServiceExtensions.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/Services/Extensions/RtmpCommandMessageSenderServiceExtensions.cs
@@ -23,7 +23,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Services.Extensions
                 { RtmpArgumentNames.Description, description }
             };
 
-            sender.SendCommandMessage(clientContext, publishStreamChunkId, "onStatus", 0, null, [properties], amfEncodingType, callback);
+            sender.SendCommandMessage(clientContext, publishStreamChunkId, "onStatus", 0, null, new List<object?> { properties }, amfEncodingType, callback);
         }
 
         public static void SendOnStatusCommandMessage(
@@ -42,7 +42,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Services.Extensions
                 { RtmpArgumentNames.Description, description }
             };
 
-            sender.SendCommandMessage(clientContexts, publishStreamChunkId, "onStatus", 0, null, [properties], amfEncodingType);
+            sender.SendCommandMessage(clientContexts, publishStreamChunkId, "onStatus", 0, null, new List<object?> { properties }, amfEncodingType);
         }
 
         public static Task SendOnStatusCommandMessageAsync(

--- a/src/LiveStreamingServerNet.Rtmp/Internal/Services/RtmpMediaMessageManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/Services/RtmpMediaMessageManagerService.cs
@@ -114,7 +114,11 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Services
             var messageHeader = new RtmpChunkMessageHeaderType0(timestamp, RtmpMessageType.DataMessageAmf0, streamId);
 
             _chunkMessageSender.Send(clientContext, basicHeader, messageHeader, (netBuffer) =>
-                netBuffer.WriteAmf([RtmpDataMessageConstants.OnMetaData, publishStreamContext.StreamMetaData], AmfEncodingType.Amf0)
+                netBuffer.WriteAmf(new List<object?>
+                {
+                    RtmpDataMessageConstants.OnMetaData,
+                    publishStreamContext.StreamMetaData
+                }, AmfEncodingType.Amf0)
             );
         }
 
@@ -131,7 +135,11 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Services
             var messageHeader = new RtmpChunkMessageHeaderType0(timestamp, RtmpMessageType.DataMessageAmf0, streamId);
 
             _chunkMessageSender.Send(clientContexts, basicHeader, messageHeader, (netBuffer) =>
-                netBuffer.WriteAmf([RtmpDataMessageConstants.OnMetaData, publishStreamContext.StreamMetaData], AmfEncodingType.Amf0)
+                netBuffer.WriteAmf(new List<object?>
+                {
+                    RtmpDataMessageConstants.OnMetaData,
+                    publishStreamContext.StreamMetaData
+                }, AmfEncodingType.Amf0)
             );
         }
 

--- a/src/LiveStreamingServerNet.Rtmp/LiveStreamingServerNet.Rtmp.csproj
+++ b/src/LiveStreamingServerNet.Rtmp/LiveStreamingServerNet.Rtmp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+
     <PackageReference Include="MediatR" Version="12.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.0" />
     <PackageReference Include="mtanksl.ActionMessageFormat" Version="1.0.4" />
     <PackageReference Include="Open.Threading.ReadWrite" Version="2.0.3" />
   </ItemGroup>

--- a/src/LiveStreamingServerNet.Rtmp/RateLimiting/BandwidthLimiter.cs
+++ b/src/LiveStreamingServerNet.Rtmp/RateLimiting/BandwidthLimiter.cs
@@ -1,5 +1,6 @@
 ﻿using LiveStreamingServerNet.Rtmp.RateLimiting.Contracts;
 using System.Diagnostics;
+using LiveStreamingServerNet.Utilities.Extensions;
 
 namespace LiveStreamingServerNet.Rtmp.RateLimiting
 {
@@ -14,8 +15,8 @@ namespace LiveStreamingServerNet.Rtmp.RateLimiting
 
         public BandwidthLimiter(long bytesPerSecond, long bytesLimit)
         {
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(bytesPerSecond, 0);
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(bytesLimit, 0);
+            ThrowHelper.ThrowIfLessThanOrEqual(bytesPerSecond, 0);
+            ThrowHelper.ThrowIfLessThanOrEqual(bytesLimit, 0);
 
             _bytesPerSecond = bytesPerSecond;
             _bytesLimit = bytesLimit;

--- a/src/LiveStreamingServerNet.Transmuxer/Internal/Services/RtmpServerStreamEventListener.cs
+++ b/src/LiveStreamingServerNet.Transmuxer/Internal/Services/RtmpServerStreamEventListener.cs
@@ -1,5 +1,6 @@
 ﻿using LiveStreamingServerNet.Rtmp.Contracts;
 using LiveStreamingServerNet.Transmuxer.Internal.Services.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
 
 namespace LiveStreamingServerNet.Transmuxer.Internal.Services
 {

--- a/src/LiveStreamingServerNet.Transmuxer/LiveStreamingServerNet.Transmuxer.csproj
+++ b/src/LiveStreamingServerNet.Transmuxer/LiveStreamingServerNet.Transmuxer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/LiveStreamingServerNet.Utilities/Extensions/DictionaryExtensions.cs
+++ b/src/LiveStreamingServerNet.Utilities/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace LiveStreamingServerNet.Utilities.Extensions;
+
+public static class DictionaryExtensions
+{
+    public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+        where TKey : notnull
+        => ((IEnumerable<KeyValuePair<TKey, TValue>>)dictionary).ToDictionary();
+
+    public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary)
+        where TKey : notnull
+        => ((IEnumerable<KeyValuePair<TKey, TValue>>)dictionary).ToDictionary();
+
+    private static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary)
+        where TKey : notnull
+    {
+        return dictionary.ToDictionary(k => k.Key, v => v.Value);
+    }
+}

--- a/src/LiveStreamingServerNet.Utilities/Extensions/ThrowHelper.cs
+++ b/src/LiveStreamingServerNet.Utilities/Extensions/ThrowHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace LiveStreamingServerNet.Utilities.Extensions;
+
+public static class ThrowHelper
+{
+    public static void ThrowIfLessThanOrEqual(long value, long limit, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if (value.CompareTo(limit) <= 0)
+            throw new ArgumentOutOfRangeException(paramName, $"The value must be greater than {limit}.");
+    }
+}

--- a/src/LiveStreamingServerNet.Utilities/LiveStreamingServerNet.Utilities.csproj
+++ b/src/LiveStreamingServerNet.Utilities/LiveStreamingServerNet.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/LiveStreamingServerNet/Common/Dtos/Mappers/StreamMapper.cs
+++ b/src/LiveStreamingServerNet/Common/Dtos/Mappers/StreamMapper.cs
@@ -41,7 +41,10 @@ namespace LiveStreamingServerNet.Standalone.Dtos.Mappers
             return defaultValue;
         }
 
-        [MapProperty([nameof(IRtmpPublishStream.Client), nameof(IClientControl.ClientId)], [nameof(StreamDto.ClientId)])]
+        [MapProperty(
+            source: new string[]
+                { nameof(IRtmpPublishStream.Client), nameof(IClientControl.ClientId) },
+            target: new string[] { nameof(StreamDto.ClientId) })]
         public static partial StreamDto ConvertToDto(IRtmpPublishStream stream);
     }
 }

--- a/src/LiveStreamingServerNet/LiveStreamingServerNet.csproj
+++ b/src/LiveStreamingServerNet/LiveStreamingServerNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/LiveStreamingServerNet/Standalone/Internal/RtmpServerStreamEventListener.cs
+++ b/src/LiveStreamingServerNet/Standalone/Internal/RtmpServerStreamEventListener.cs
@@ -14,17 +14,17 @@ namespace LiveStreamingServerNet.Standalone.Internal
 
         public async ValueTask OnRtmpStreamMetaDataReceived(uint clientId, string streamPath, IReadOnlyDictionary<string, object> metaData)
         {
-            await _streamManager.RtmpStreamMetaDataReceived(clientId, streamPath, metaData.ToDictionary());
+            await _streamManager.RtmpStreamMetaDataReceived(clientId, streamPath, metaData);
         }
 
         public async ValueTask OnRtmpStreamPublishedAsync(uint clientId, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
         {
-            await _streamManager.RtmpStreamPublishedAsync(clientId, streamPath, streamArguments.ToDictionary());
+            await _streamManager.RtmpStreamPublishedAsync(clientId, streamPath, streamArguments);
         }
 
         public async ValueTask OnRtmpStreamSubscribedAsync(uint clientId, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
         {
-            await _streamManager.RtmpStreamSubscribedAsync(clientId, streamPath, streamArguments.ToDictionary());
+            await _streamManager.RtmpStreamSubscribedAsync(clientId, streamPath, streamArguments);
         }
 
         public async ValueTask OnRtmpStreamUnpublishedAsync(uint clientId, string streamPath)


### PR DESCRIPTION
Hi,

When I found your implementation I was really excited to use it, it works great and I want to integrate this into my own project. Unfortunately, it targets Net7.0 and it is currently not possible to update it because of other dependencies. That is why I added Net 7.0 to your implementation.

Please let me know what you think. 
Thanks in advance.

- Jordy

* I tested the standalone & rtmps sample projects using both net8 and 7 