### PR TITLE
Support RTMP relay triggering on FLV request

### DIFF
--- a/LiveStreamingServerNet.sln
+++ b/LiveStreamingServerNet.sln
@@ -89,7 +89,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiveStreamingServerNet.Rtmp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiveStreamingServerNet.RtmpRelayDemo", "samples\LiveStreamingServerNet.RtmpRelayDemo\LiveStreamingServerNet.RtmpRelayDemo.csproj", "{ACA0D693-602E-4DBC-92A9-4188B86E4B45}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveStreamingServerNet.Rtmp.Relay", "src\LiveStreamingServerNet.Rtmp.Relay\LiveStreamingServerNet.Rtmp.Relay.csproj", "{D70CEDC6-7E56-4AE2-9192-3EB382397483}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiveStreamingServerNet.Rtmp.Relay", "src\LiveStreamingServerNet.Rtmp.Relay\LiveStreamingServerNet.Rtmp.Relay.csproj", "{D70CEDC6-7E56-4AE2-9192-3EB382397483}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveStreamingServerNet.FlvRelayDemo", "samples\LiveStreamingServerNet.FlvRelayDemo\LiveStreamingServerNet.FlvRelayDemo.csproj", "{2601B1E7-2996-4A0A-ADEB-A17A7E18EAF1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -265,6 +267,10 @@ Global
 		{D70CEDC6-7E56-4AE2-9192-3EB382397483}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D70CEDC6-7E56-4AE2-9192-3EB382397483}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D70CEDC6-7E56-4AE2-9192-3EB382397483}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2601B1E7-2996-4A0A-ADEB-A17A7E18EAF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2601B1E7-2996-4A0A-ADEB-A17A7E18EAF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2601B1E7-2996-4A0A-ADEB-A17A7E18EAF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2601B1E7-2996-4A0A-ADEB-A17A7E18EAF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -292,6 +298,7 @@ Global
 		{17841723-77DF-4A42-9C24-38EB71203D39} = {45761E33-F086-403D-BB6E-8059F8CC6BA8}
 		{6887F6DF-CE3F-4D6E-8E66-6A8151CA2680} = {45761E33-F086-403D-BB6E-8059F8CC6BA8}
 		{ACA0D693-602E-4DBC-92A9-4188B86E4B45} = {45761E33-F086-403D-BB6E-8059F8CC6BA8}
+		{2601B1E7-2996-4A0A-ADEB-A17A7E18EAF1} = {45761E33-F086-403D-BB6E-8059F8CC6BA8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0A9A3928-2852-49B9-85EF-F00480E9FE7F}

--- a/samples/LiveStreamingServerNet.FlvRelayDemo/LiveStreamingServerNet.FlvRelayDemo.csproj
+++ b/samples/LiveStreamingServerNet.FlvRelayDemo/LiveStreamingServerNet.FlvRelayDemo.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LiveStreamingServerNet.Flv\LiveStreamingServerNet.Flv.csproj" />
+    <ProjectReference Include="..\..\src\LiveStreamingServerNet\LiveStreamingServerNet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/LiveStreamingServerNet.FlvRelayDemo/Program.cs
+++ b/samples/LiveStreamingServerNet.FlvRelayDemo/Program.cs
@@ -1,10 +1,10 @@
 using LiveStreamingServerNet.Flv.Installer;
-using System.Net;
-using System.Text.RegularExpressions;
-using System.Text;
 using LiveStreamingServerNet.Rtmp.Relay;
 using LiveStreamingServerNet.Rtmp.Relay.Contracts;
 using LiveStreamingServerNet.Rtmp.Relay.Installer;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace LiveStreamingServerNet.FlvRelayDemo
 {

--- a/samples/LiveStreamingServerNet.FlvRelayDemo/Program.cs
+++ b/samples/LiveStreamingServerNet.FlvRelayDemo/Program.cs
@@ -1,0 +1,122 @@
+using LiveStreamingServerNet.Flv.Installer;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Text;
+using LiveStreamingServerNet.Rtmp.Relay;
+using LiveStreamingServerNet.Rtmp.Relay.Contracts;
+using LiveStreamingServerNet.Rtmp.Relay.Installer;
+
+namespace LiveStreamingServerNet.FlvRelayDemo
+{
+    public static class Program
+    {
+        public static async Task Main()
+        {
+            await using var origin = CreateOriginServer(1935);
+            await using var relay1 = CreateRelayServer(1936);
+            await using var relay2 = CreateRelayServer(1937);
+
+            await Task.WhenAll(
+                origin.RunAsync("http://+:9000"),
+                relay1.RunAsync("http://+:9001"),
+                relay2.RunAsync("http://+:9002")
+            );
+        }
+
+        private static WebApplication CreateOriginServer(int rtmpPort)
+        {
+            var builder = WebApplication.CreateBuilder();
+
+            builder.Services.AddLiveStreamingServer(
+                new IPEndPoint(IPAddress.Any, rtmpPort),
+                options => options.AddFlv()
+            );
+
+            var app = builder.Build();
+
+            app.UseWebSockets();
+
+            app.UseWebSocketFlv();
+
+            app.UseHttpFlv();
+
+            return app;
+        }
+
+        private static WebApplication CreateRelayServer(int rtmpPort)
+        {
+            var builder = WebApplication.CreateBuilder();
+
+            builder.Services.AddLiveStreamingServer(
+                new IPEndPoint(IPAddress.Any, rtmpPort),
+                options => options
+                    .AddFlv()
+                    .UseRtmpRelay<RtmpOriginResolver>()
+            );
+
+            var app = builder.Build();
+
+            app.UseWebSockets();
+
+            app.UseWebSocketFlv();
+
+            app.UseHttpFlv();
+
+            return app;
+        }
+    }
+
+    public partial class RtmpOriginResolver : IRtmpOriginResolver
+    {
+        [GeneratedRegex(@"/?(?<appName>[^/]+)/(?<streamName>.+)$", RegexOptions.IgnoreCase)]
+        private static partial Regex NamesExtractionRegex();
+
+        public ValueTask<RtmpOrigin?> ResolveUpstreamOriginAsync(
+            string streamPath, IReadOnlyDictionary<string, string> streamArguments, CancellationToken cancellationToken)
+        {
+            return ResolveOriginAsync(streamPath, streamArguments);
+        }
+
+        public ValueTask<RtmpOrigin?> ResolveDownstreamOriginAsync(string streamPath, CancellationToken cancellationToken)
+        {
+            return ResolveOriginAsync(streamPath, null);
+        }
+
+        private static ValueTask<RtmpOrigin?> ResolveOriginAsync(string streamPath, IReadOnlyDictionary<string, string>? streamArguments)
+        {
+            var match = NamesExtractionRegex().Match(streamPath);
+
+            if (!match.Success)
+                return ValueTask.FromResult<RtmpOrigin?>(null);
+
+            var appName = match.Groups["appName"].Value;
+            var streamName = CreateStreamName(match.Groups["streamName"].Value, streamArguments);
+
+            var result = new RtmpOrigin(new IPEndPoint(IPAddress.Loopback, 1935), appName, streamName);
+            return ValueTask.FromResult<RtmpOrigin?>(result);
+        }
+
+        private static string CreateStreamName(string streamName, IReadOnlyDictionary<string, string>? streamArguments)
+        {
+            var streamNameBuilder = new StringBuilder();
+            streamNameBuilder.Append(streamName);
+
+            if (streamArguments?.Any() == true)
+            {
+                streamNameBuilder.Append('?');
+
+                foreach (var (key, value) in streamArguments)
+                {
+                    streamNameBuilder.Append(key);
+                    streamNameBuilder.Append('=');
+                    streamNameBuilder.Append(value);
+                    streamNameBuilder.Append('&');
+                }
+
+                streamNameBuilder.Length--;
+            }
+
+            return streamNameBuilder.ToString();
+        }
+    }
+}

--- a/samples/LiveStreamingServerNet.RtmpClientPublishDemo/Program.cs
+++ b/samples/LiveStreamingServerNet.RtmpClientPublishDemo/Program.cs
@@ -60,8 +60,9 @@ namespace LiveStreamingServerNet.RtmpClientPublishDemo
 
             try
             {
-                await Task.WhenAny(SendMediaDataAsync(rtmpStream, flvReader, cts), rtmpClient.UntilStoppedAsync());
+                await Task.WhenAny(SendMediaDataAsync(rtmpStream, flvReader, cts), rtmpClient.UntilStoppedAsync(cts.Token));
             }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested) { }
             finally
             {
                 cts.Cancel();

--- a/src/LiveStreamingServerNet.Flv/Configurations/MediaStreamingConfiguration.cs
+++ b/src/LiveStreamingServerNet.Flv/Configurations/MediaStreamingConfiguration.cs
@@ -1,10 +1,11 @@
 ﻿namespace LiveStreamingServerNet.Flv.Configurations
 {
-    public class MediaStraemingConfiguration
+    public class MediaStreamingConfiguration
     {
         public int TargetOutstandingMediaPacketsCount { get; set; } = 64;
         public long TargetOutstandingMediaPacketsSize { get; set; } = 1024 * 1024;
         public int MaxOutstandingMediaPacketsCount { get; set; } = 512;
         public long MaxOutstandingMediaPacketsSize { get; set; } = 8 * 1024 * 1024;
+        public TimeSpan ReadinessTimeout { get; set; } = TimeSpan.FromSeconds(15);
     }
 }

--- a/src/LiveStreamingServerNet.Flv/Installer/Contracts/IFlvConfigurator.cs
+++ b/src/LiveStreamingServerNet.Flv/Installer/Contracts/IFlvConfigurator.cs
@@ -4,6 +4,6 @@ namespace LiveStreamingServerNet.Flv.Installer.Contracts
 {
     public interface IFlvConfigurator
     {
-        IFlvConfigurator ConfigureMediaStreaming(Action<MediaStraemingConfiguration>? configure);
+        IFlvConfigurator ConfigureMediaStreaming(Action<MediaStreamingConfiguration>? configure);
     }
 }

--- a/src/LiveStreamingServerNet.Flv/Installer/FlvConfigurator.cs
+++ b/src/LiveStreamingServerNet.Flv/Installer/FlvConfigurator.cs
@@ -13,7 +13,7 @@ namespace LiveStreamingServerNet.Flv.Installer
             _services = services;
         }
 
-        public IFlvConfigurator ConfigureMediaStreaming(Action<MediaStraemingConfiguration>? configure)
+        public IFlvConfigurator ConfigureMediaStreaming(Action<MediaStreamingConfiguration>? configure)
         {
             if (configure != null)
                 _services.Configure(configure);

--- a/src/LiveStreamingServerNet.Flv/Internal/Contracts/IFlvClient.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Contracts/IFlvClient.cs
@@ -9,8 +9,8 @@ namespace LiveStreamingServerNet.Flv.Internal.Contracts
         CancellationToken StoppingToken { get; }
         void Stop();
         void CompleteInitialization();
-        Task UntilInitializationCompleteAsync();
-        Task UntilCompleteAsync();
+        Task UntilInitializationCompleteAsync(CancellationToken cancellationToken = default);
+        Task UntilCompleteAsync(CancellationToken cancellationToken = default);
         ValueTask WriteHeaderAsync(bool allowAudioTags, bool allowVideoTags, CancellationToken cancellationToken);
         ValueTask WriteTagAsync(FlvTagType tagType, uint timestamp, Action<IDataBuffer> payloadBuffer, CancellationToken cancellationToken);
     }

--- a/src/LiveStreamingServerNet.Flv/Internal/Contracts/IFlvStreamContext.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Contracts/IFlvStreamContext.cs
@@ -12,7 +12,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Contracts
         byte[]? AudioSequenceHeader { get; set; }
         IGroupOfPicturesCache GroupOfPicturesCache { get; }
         bool IsReady { get; }
-        Task UntilReadyAsync();
+        Task UntilReadyAsync(CancellationToken cancellationToken = default);
 
         void SetReady();
     }

--- a/src/LiveStreamingServerNet.Flv/Internal/Contracts/IFlvStreamContext.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Contracts/IFlvStreamContext.cs
@@ -12,6 +12,9 @@ namespace LiveStreamingServerNet.Flv.Internal.Contracts
         byte[]? AudioSequenceHeader { get; set; }
         IGroupOfPicturesCache GroupOfPicturesCache { get; }
         bool IsReady { get; }
+        Task UntilReadyAsync();
+
+        void SetReady();
     }
 
     internal interface IGroupOfPicturesCache : IDisposable

--- a/src/LiveStreamingServerNet.Flv/Internal/FlvClient.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/FlvClient.cs
@@ -88,12 +88,12 @@ namespace LiveStreamingServerNet.Flv.Internal
 
             _isDisposed = true;
 
-            _mediaTagBroadcaster.UnregisterClient(this);
+            await _mediaTagBroadcaster.UnregisterClientAsync(this);
+
             _stoppingCts.Cancel();
             _stoppingCts.Dispose();
-            await _flvWriter.DisposeAsync();
 
-            GC.SuppressFinalize(this);
+            await _flvWriter.DisposeAsync();
         }
 
         public async ValueTask WriteHeaderAsync(bool allowAudioTags, bool allowVideoTags, CancellationToken cancellationToken)

--- a/src/LiveStreamingServerNet.Flv/Internal/FlvClient.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/FlvClient.cs
@@ -58,7 +58,7 @@ namespace LiveStreamingServerNet.Flv.Internal
 
         public void CompleteInitialization()
         {
-            _initializationTcs.SetResult();
+            _initializationTcs.TrySetResult();
         }
 
         public Task UntilInitializationCompleteAsync()

--- a/src/LiveStreamingServerNet.Flv/Internal/FlvClient.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/FlvClient.cs
@@ -2,6 +2,7 @@
 using LiveStreamingServerNet.Flv.Internal.Logging;
 using LiveStreamingServerNet.Flv.Internal.Services.Contracts;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace LiveStreamingServerNet.Flv.Internal
@@ -61,19 +62,23 @@ namespace LiveStreamingServerNet.Flv.Internal
             _initializationTcs.TrySetResult();
         }
 
-        public Task UntilInitializationCompleteAsync()
+        public Task UntilInitializationCompleteAsync(CancellationToken cancellationToken)
         {
-            return _initializationTask;
+            return _initializationTask.WithCancellation(cancellationToken);
         }
 
-        public Task UntilCompleteAsync()
+        public Task UntilCompleteAsync(CancellationToken cancellationToken)
         {
-            return _completeTask;
+            return _completeTask.WithCancellation(cancellationToken);
         }
 
         public void Stop()
         {
-            _stoppingCts.Cancel();
+            try
+            {
+                _stoppingCts.Cancel();
+            }
+            catch (ObjectDisposedException) { }
         }
 
         public async ValueTask DisposeAsync()

--- a/src/LiveStreamingServerNet.Flv/Internal/FlvStreamContext.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/FlvStreamContext.cs
@@ -1,6 +1,7 @@
 ﻿using LiveStreamingServerNet.Flv.Internal.Contracts;
 using LiveStreamingServerNet.Utilities.Buffers;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
 using System.Runtime.CompilerServices;
 
 namespace LiveStreamingServerNet.Flv.Internal
@@ -35,9 +36,9 @@ namespace LiveStreamingServerNet.Flv.Internal
             _isReady = true;
         }
 
-        public Task UntilReadyAsync()
+        public Task UntilReadyAsync(CancellationToken cancellationToken)
         {
-            return _readyTcs.Task;
+            return _readyTcs.Task.WithCancellation(cancellationToken);
         }
 
         public void Dispose()

--- a/src/LiveStreamingServerNet.Flv/Internal/FlvStreamContext.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/FlvStreamContext.cs
@@ -2,7 +2,6 @@
 using LiveStreamingServerNet.Utilities.Buffers;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.Extensions;
-using System.Runtime.CompilerServices;
 
 namespace LiveStreamingServerNet.Flv.Internal
 {
@@ -26,7 +25,6 @@ namespace LiveStreamingServerNet.Flv.Internal
             GroupOfPicturesCache = new GroupOfPicturesCache(bufferPool);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetReady()
         {
             if (_isReady)

--- a/src/LiveStreamingServerNet.Flv/Internal/FlvWriter.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/FlvWriter.cs
@@ -23,7 +23,7 @@ namespace LiveStreamingServerNet.Flv.Internal
         {
             try
             {
-                await _syncLock.WaitAsync(cancellationToken);
+                using var _ = await _syncLock.LockAsync(cancellationToken);
 
                 byte typeFlags = 0;
 
@@ -39,10 +39,6 @@ namespace LiveStreamingServerNet.Flv.Internal
                     }, cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
-            finally
-            {
-                _syncLock.Release();
-            }
         }
 
         public async ValueTask WriteTagAsync(FlvTagType tagType, uint timestamp, Action<IDataBuffer> payloadBuffer, CancellationToken cancellationToken)

--- a/src/LiveStreamingServerNet.Flv/Internal/Logging/LoggerExtensions.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Logging/LoggerExtensions.cs
@@ -21,5 +21,8 @@ namespace LiveStreamingServerNet.Flv.Internal.Logging
 
         [LoggerMessage(LogLevel.Error, "Stream readiness timeout (StreamPath={StreamPath})")]
         public static partial void ReadinessTimeout(this ILogger logger, string streamPath);
+
+        [LoggerMessage(LogLevel.Error, "An error occurred while running client (StreamPath={StreamPath})")]
+        public static partial void RunClientError(this ILogger logger, string streamPath, Exception ex);
     }
 }

--- a/src/LiveStreamingServerNet.Flv/Internal/Logging/LoggerExtensions.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Logging/LoggerExtensions.cs
@@ -18,5 +18,8 @@ namespace LiveStreamingServerNet.Flv.Internal.Logging
 
         [LoggerMessage(LogLevel.Debug, "End media packet discard (ClientId={ClientId}, OutstandingSize={OutstandingSize}, OutstandingCount={OutstandingCount})")]
         public static partial void EndMediaPacketDiscard(this ILogger logger, string clientId, long outstandingSize, long outstandingCount);
+
+        [LoggerMessage(LogLevel.Error, "Stream readiness timeout (StreamPath={StreamPath})")]
+        public static partial void ReadinessTimeout(this ILogger logger, string streamPath);
     }
 }

--- a/src/LiveStreamingServerNet.Flv/Internal/MediaPacketDiscarders/MediaPacketDiscarderFactory.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/MediaPacketDiscarders/MediaPacketDiscarderFactory.cs
@@ -10,10 +10,10 @@ namespace LiveStreamingServerNet.Flv.Internal.MediaPacketDiscarders
 {
     internal class MediaPacketDiscarderFactory : IMediaPacketDiscarderFactory
     {
-        private readonly MediaStraemingConfiguration _config;
+        private readonly MediaStreamingConfiguration _config;
         private readonly ILogger<PacketDiscarder> _logger;
 
-        public MediaPacketDiscarderFactory(IOptions<MediaStraemingConfiguration> config, ILogger<PacketDiscarder> logger)
+        public MediaPacketDiscarderFactory(IOptions<MediaStreamingConfiguration> config, ILogger<PacketDiscarder> logger)
         {
             _config = config.Value;
             _logger = logger;

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/Contracts/IFlvClientHandler.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/Contracts/IFlvClientHandler.cs
@@ -4,6 +4,6 @@ namespace LiveStreamingServerNet.Flv.Internal.Services.Contracts
 {
     internal interface IFlvClientHandler
     {
-        Task RunClientAsync(IFlvClient client);
+        Task RunClientAsync(IFlvClient client, CancellationToken cancellationToken);
     }
 }

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/Contracts/IFlvMediaTagBroadcasterService.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/Contracts/IFlvMediaTagBroadcasterService.cs
@@ -15,6 +15,6 @@ namespace LiveStreamingServerNet.Flv.Internal.Services.Contracts
             IRentedBuffer rentedBuffer);
 
         void RegisterClient(IFlvClient client);
-        void UnregisterClient(IFlvClient client);
+        ValueTask UnregisterClientAsync(IFlvClient client);
     }
 }

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/Contracts/IFlvStreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/Contracts/IFlvStreamManagerService.cs
@@ -10,7 +10,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Services.Contracts
         bool StopPublishingStream(string streamPath, out IList<IFlvClient> existingSubscribers);
         IFlvStreamContext? GetFlvStreamContext(string streamPath);
 
-        SubscribingStreamResult StartSubscribingStream(IFlvClient client, string streamPath);
+        SubscribingStreamResult StartSubscribingStream(IFlvClient client, string streamPath, bool requireReady = true);
         bool StopSubscribingStream(IFlvClient client);
         IReadOnlyList<IFlvClient> GetSubscribers(string streamPath);
     }

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/FlvClientHandler.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/FlvClientHandler.cs
@@ -1,5 +1,10 @@
-﻿using LiveStreamingServerNet.Flv.Internal.Contracts;
+﻿using LiveStreamingServerNet.Flv.Configurations;
+using LiveStreamingServerNet.Flv.Internal.Contracts;
+using LiveStreamingServerNet.Flv.Internal.Logging;
 using LiveStreamingServerNet.Flv.Internal.Services.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace LiveStreamingServerNet.Flv.Internal.Services
 {
@@ -7,11 +12,19 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
     {
         private readonly IFlvStreamManagerService _streamManager;
         private readonly IFlvMediaTagCacherService _mediaTagCacher;
+        private readonly MediaStreamingConfiguration _config;
+        private readonly ILogger _logger;
 
-        public FlvClientHandler(IFlvStreamManagerService streamManager, IFlvMediaTagCacherService mediaTagCacher)
+        public FlvClientHandler(
+            IFlvStreamManagerService streamManager,
+            IFlvMediaTagCacherService mediaTagCacher,
+            IOptions<MediaStreamingConfiguration> config,
+            ILogger<FlvClientHandler> logger)
         {
             _streamManager = streamManager;
             _mediaTagCacher = mediaTagCacher;
+            _config = config.Value;
+            _logger = logger;
         }
 
         public async Task RunClientAsync(IFlvClient client)
@@ -19,6 +32,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
             try
             {
                 var streamContext = _streamManager.GetFlvStreamContext(client.StreamPath)!;
+                await UntilReadyAsync(streamContext);
 
                 await SendFlvHeaderAsync(client, streamContext, client.StoppingToken);
                 await SendCachedFlvTagsAsync(client, streamContext, client.StoppingToken);
@@ -29,6 +43,18 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
             finally
             {
                 _streamManager.StopSubscribingStream(client);
+            }
+        }
+
+        private async Task UntilReadyAsync(IFlvStreamContext streamContext)
+        {
+            using var cts = new CancellationTokenSource(_config.ReadinessTimeout);
+            await streamContext.UntilReadyAsync().WithCancellation(cts.Token);
+
+            if (cts.IsCancellationRequested)
+            {
+                _logger.ReadinessTimeout(streamContext.StreamPath);
+                throw new TimeoutException();
             }
         }
 

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/FlvClientHandler.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/FlvClientHandler.cs
@@ -39,8 +39,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
                 client.CompleteInitialization();
                 await client.UntilCompleteAsync(cancellationToken);
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
-            catch (OperationCanceledException) when (client.StoppingToken.IsCancellationRequested) { }
+            catch (OperationCanceledException) { }
             catch (Exception ex)
             {
                 _logger.RunClientError(client.StreamPath, ex);

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/FlvMediaTagBroadcasterService.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/FlvMediaTagBroadcasterService.cs
@@ -106,12 +106,6 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
                             packet.Timestamp,
                             cancellation);
                     }
-                    catch (OperationCanceledException) when (client.StoppingToken.IsCancellationRequested) { }
-                    catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { }
-                    catch (Exception ex)
-                    {
-                        _logger.FailedToSendMediaMessage(client.ClientId, ex);
-                    }
                     finally
                     {
                         packet.RentedPayload.Unclaim();
@@ -126,6 +120,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
                 _logger.FailedToSendMediaMessage(client.ClientId, ex);
             }
 
+            client.Stop();
             context.Cleanup();
         }
 

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/FlvMediaTagBroadcasterService.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/FlvMediaTagBroadcasterService.cs
@@ -6,7 +6,6 @@ using LiveStreamingServerNet.Rtmp;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.PacketDiscarders.Contracts;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Concurrent;
 using System.Threading.Channels;
 

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/FlvMediaTagBroadcasterService.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/FlvMediaTagBroadcasterService.cs
@@ -69,11 +69,12 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
             _ = clientTask.ContinueWith(_ => _clientTasks.TryRemove(client, out var _));
         }
 
-        public void UnregisterClient(IFlvClient client)
+        public async ValueTask UnregisterClientAsync(IFlvClient client)
         {
             if (_clientMediaContexts.TryRemove(client, out var context))
             {
                 context.Stop();
+                await context.UntilCompleteAsync();
             }
         }
 
@@ -121,32 +122,37 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
 
             client.Stop();
             context.Cleanup();
+            context.Complete();
         }
 
         private class ClientMediaContext
         {
             public readonly IFlvClient Client;
             public readonly CancellationToken CancellationToken;
-            public long OutstandingPacketsSize => _outstandingPacketsSize;
-            public long OutstandingPacketsCount => _outstandingPacketCount;
 
             private readonly IPacketDiscarder _mediaPacketDiscarder;
 
             private readonly Channel<ClientMediaPacket> _packetChannel;
             private readonly CancellationTokenSource _cts;
+            private readonly TaskCompletionSource _tcs;
 
             private long _outstandingPacketsSize;
             private long _outstandingPacketCount;
 
+            public long OutstandingPacketsSize => _outstandingPacketsSize;
+            public long OutstandingPacketsCount => _outstandingPacketCount;
+
             public ClientMediaContext(IFlvClient client, IPacketDiscarder mediaPacketDiscarder)
             {
-                Client = client;
                 _mediaPacketDiscarder = mediaPacketDiscarder;
 
                 _packetChannel = Channel.CreateUnbounded<ClientMediaPacket>(
                     new UnboundedChannelOptions { SingleReader = true, AllowSynchronousContinuations = true });
 
                 _cts = new CancellationTokenSource();
+                _tcs = new TaskCompletionSource();
+
+                Client = client;
                 CancellationToken = _cts.Token;
             }
 
@@ -202,6 +208,16 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
                 }
 
                 return result;
+            }
+
+            public void Complete()
+            {
+                _tcs.TrySetResult();
+            }
+
+            public Task UntilCompleteAsync()
+            {
+                return _tcs.Task;
             }
 
             private bool ShouldSkipPacket(ClientMediaContext context, ref ClientMediaPacket packet)

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/FlvStreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/FlvStreamManagerService.cs
@@ -69,7 +69,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
             }
         }
 
-        public SubscribingStreamResult StartSubscribingStream(IFlvClient client, string streamPath)
+        public SubscribingStreamResult StartSubscribingStream(IFlvClient client, string streamPath, bool requireReady)
         {
             lock (_publishingSyncLock)
             {
@@ -78,7 +78,7 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
                     if (_subscribedStreamPaths.ContainsKey(client))
                         return SubscribingStreamResult.AlreadySubscribing;
 
-                    if (!_publishingStreamContexts.TryGetValue(streamPath, out var stream) || !stream.IsReady)
+                    if (!_publishingStreamContexts.TryGetValue(streamPath, out var stream) || (requireReady && !stream.IsReady))
                         return SubscribingStreamResult.StreamDoesntExist;
 
                     if (!_subscribingClients.TryGetValue(streamPath, out var subscribers))

--- a/src/LiveStreamingServerNet.Flv/Internal/Services/RtmpMediaMessageScraper.cs
+++ b/src/LiveStreamingServerNet.Flv/Internal/Services/RtmpMediaMessageScraper.cs
@@ -24,6 +24,8 @@ namespace LiveStreamingServerNet.Flv.Internal.Services
             if (streamContext == null)
                 return;
 
+            streamContext.SetReady();
+
             var subscribers = _streamManager.GetSubscribers(streamPath);
             if (!subscribers.Any())
                 return;

--- a/src/LiveStreamingServerNet.Flv/LiveStreamingServerNet.Flv.csproj
+++ b/src/LiveStreamingServerNet.Flv/LiveStreamingServerNet.Flv.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\LiveStreamingServerNet.Rtmp.Server\LiveStreamingServerNet.Rtmp.Server.csproj" />
+    <ProjectReference Include="..\LiveStreamingServerNet.Rtmp.Relay\LiveStreamingServerNet.Rtmp.Relay.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/LiveStreamingServerNet.Flv/Middlewares/HttpFlvMiddleware.cs
+++ b/src/LiveStreamingServerNet.Flv/Middlewares/HttpFlvMiddleware.cs
@@ -88,7 +88,7 @@ namespace LiveStreamingServerNet.Flv.Middlewares
             switch (_streamManager.StartSubscribingStream(client, streamPath, !UseRelay()))
             {
                 case SubscribingStreamResult.Succeeded:
-                    await _clientHandler.RunClientAsync(client);
+                    await _clientHandler.RunClientAsync(client, cancellation);
                     return;
                 case SubscribingStreamResult.StreamDoesntExist:
                     context.Response.StatusCode = StatusCodes.Status404NotFound;

--- a/src/LiveStreamingServerNet.Flv/Middlewares/WebSocketFlvMiddleware.cs
+++ b/src/LiveStreamingServerNet.Flv/Middlewares/WebSocketFlvMiddleware.cs
@@ -87,7 +87,7 @@ namespace LiveStreamingServerNet.Flv.Middlewares
             switch (_streamManager.StartSubscribingStream(client, streamPath, !UseRelay()))
             {
                 case SubscribingStreamResult.Succeeded:
-                    await _clientHandler.RunClientAsync(client);
+                    await _clientHandler.RunClientAsync(client, cancellation);
                     return;
                 case SubscribingStreamResult.StreamDoesntExist:
                     context.Response.StatusCode = StatusCodes.Status404NotFound;

--- a/src/LiveStreamingServerNet.Flv/Middlewares/WebSocketFlvMiddleware.cs
+++ b/src/LiveStreamingServerNet.Flv/Middlewares/WebSocketFlvMiddleware.cs
@@ -5,9 +5,11 @@ using LiveStreamingServerNet.Flv.Internal.Extensions;
 using LiveStreamingServerNet.Flv.Internal.Services.Contracts;
 using LiveStreamingServerNet.Flv.Internal.WebSocketClients.Contracts;
 using LiveStreamingServerNet.Networking.Server.Contracts;
+using LiveStreamingServerNet.Rtmp.Relay.Contracts;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System.Diagnostics;
 using System.Net.WebSockets;
 
 namespace LiveStreamingServerNet.Flv.Middlewares
@@ -17,6 +19,7 @@ namespace LiveStreamingServerNet.Flv.Middlewares
         private readonly IWebSocketFlvClientFactory _clientFactory;
         private readonly IFlvStreamManagerService _streamManager;
         private readonly IFlvClientHandler _clientHandler;
+        private readonly IRtmpRelayManager? _relayManager;
 
         private readonly IStreamPathResolver _streamPathResolver;
         private readonly WebSocketAcceptContext _webSocketAcceptContext;
@@ -29,6 +32,7 @@ namespace LiveStreamingServerNet.Flv.Middlewares
             _clientFactory = server.Services.GetRequiredService<IWebSocketFlvClientFactory>();
             _streamManager = server.Services.GetRequiredService<IFlvStreamManagerService>();
             _clientHandler = server.Services.GetRequiredService<IFlvClientHandler>();
+            _relayManager = server.Services.GetService<IRtmpRelayManager>();
 
             _streamPathResolver = options.Value.StreamPathResolver ?? new DefaultStreamPathResolver();
             _webSocketAcceptContext = options.Value.WebSocketAcceptContext ?? new WebSocketAcceptContext();
@@ -57,7 +61,7 @@ namespace LiveStreamingServerNet.Flv.Middlewares
 
         private async Task TryServeWebSocketFlv(HttpContext context, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
         {
-            if (!_streamManager.IsStreamPathPublishing(streamPath))
+            if (!_streamManager.IsStreamPathPublishing(streamPath) && !UseRelay())
             {
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
                 return;
@@ -76,9 +80,11 @@ namespace LiveStreamingServerNet.Flv.Middlewares
             var cancellation = context.RequestAborted;
 
             var webSocket = await context.WebSockets.AcceptWebSocketAsync(_webSocketAcceptContext);
-            await using var client = CreateClient(webSocket, streamPath, cancellation);
 
-            switch (_streamManager.StartSubscribingStream(client, streamPath))
+            await using var client = CreateClient(webSocket, streamPath, cancellation);
+            using var relaySubscriber = await RequestDownstreamAsync(streamPath, cancellation);
+
+            switch (_streamManager.StartSubscribingStream(client, streamPath, !UseRelay()))
             {
                 case SubscribingStreamResult.Succeeded:
                     await _clientHandler.RunClientAsync(client);
@@ -89,6 +95,20 @@ namespace LiveStreamingServerNet.Flv.Middlewares
                 case SubscribingStreamResult.AlreadySubscribing:
                     throw new InvalidOperationException("Already subscribing");
             }
+        }
+
+        private async Task<IRtmpDownstreamSubscriber?> RequestDownstreamAsync(string streamPath, CancellationToken cancellationToken = default)
+        {
+            if (!UseRelay())
+                return null;
+
+            Debug.Assert(_relayManager != null);
+            return await _relayManager.RequestDownstreamAsync(streamPath, cancellationToken);
+        }
+
+        private bool UseRelay()
+        {
+            return _relayManager != null;
         }
     }
 }

--- a/src/LiveStreamingServerNet.Networking.Server/Internal/ClientSessionManager.cs
+++ b/src/LiveStreamingServerNet.Networking.Server/Internal/ClientSessionManager.cs
@@ -78,7 +78,11 @@ namespace LiveStreamingServerNet.Networking.Server.Internal
 
         public async Task WaitUntilAllClientTasksCompleteAsync(CancellationToken cancellationToken)
         {
-            await Task.WhenAll(_clientSessionTasks.Select(x => x.Value.Task)).WithCancellation(cancellationToken);
+            try
+            {
+                await Task.WhenAll(_clientSessionTasks.Select(x => x.Value.Task)).WithCancellation(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
         }
 
         private async Task OnClientAcceptedAsync(ITcpClient tcpClient)

--- a/src/LiveStreamingServerNet.Networking.Server/Internal/Server.cs
+++ b/src/LiveStreamingServerNet.Networking.Server/Internal/Server.cs
@@ -69,7 +69,7 @@ namespace LiveStreamingServerNet.Networking.Server.Internal
                 serverException = ex;
             }
 
-            await _clientSessionManager.WaitUntilAllClientTasksCompleteAsync();
+            await WaitUntilAllClientTasksCompleteAsync();
 
             StopAllTcpListeners(serverListeners);
 
@@ -77,6 +77,15 @@ namespace LiveStreamingServerNet.Networking.Server.Internal
 
             if (serverException != null)
                 throw serverException;
+        }
+
+        private async Task WaitUntilAllClientTasksCompleteAsync()
+        {
+            try
+            {
+                await _clientSessionManager.WaitUntilAllClientTasksCompleteAsync();
+            }
+            catch { }
         }
 
         private void StopAllTcpListeners(List<ServerListener> serverListeners)

--- a/src/LiveStreamingServerNet.Networking/Internal/BufferSender.cs
+++ b/src/LiveStreamingServerNet.Networking/Internal/BufferSender.cs
@@ -30,7 +30,7 @@ namespace LiveStreamingServerNet.Networking.Internal
         public void Start(INetworkStreamWriter networkStream, CancellationToken cancellationToken)
         {
             _networkStream = networkStream;
-            _task = Task.Run(() => SendOutstandingBuffersAsync(networkStream, cancellationToken), cancellationToken);
+            _task = Task.Run(() => SendOutstandingBuffersAsync(networkStream, cancellationToken));
         }
 
         public void Send(IDataBuffer dataBuffer, Action<bool>? callback)

--- a/src/LiveStreamingServerNet.Networking/Internal/Session.cs
+++ b/src/LiveStreamingServerNet.Networking/Internal/Session.cs
@@ -145,7 +145,12 @@ namespace LiveStreamingServerNet.Networking.Internal
         public async Task DisconnectAsync(CancellationToken cancellation)
         {
             Disconnect();
-            await _stoppedTcs.Task.WithCancellation(cancellation);
+
+            try
+            {
+                await _stoppedTcs.Task.WithCancellation(cancellation);
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { }
         }
 
         private async Task DisposeAsync(IAsyncDisposable? disposable)

--- a/src/LiveStreamingServerNet.Networking/Internal/Session.cs
+++ b/src/LiveStreamingServerNet.Networking/Internal/Session.cs
@@ -135,7 +135,11 @@ namespace LiveStreamingServerNet.Networking.Internal
 
         public void Disconnect()
         {
-            _cts.Cancel();
+            try
+            {
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException) { }
         }
 
         public async Task DisconnectAsync(CancellationToken cancellation)

--- a/src/LiveStreamingServerNet.Rtmp.Client/Contracts/IRtmpClient.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Contracts/IRtmpClient.cs
@@ -15,7 +15,7 @@ namespace LiveStreamingServerNet.Rtmp.Client.Contracts
         void Command(RtmpCommand command);
         Task<RtmpCommandResponse> CommandAsync(RtmpCommand command);
 
-        Task UntilStoppedAsync();
+        Task UntilStoppedAsync(CancellationToken cancellationToken = default);
         void Stop();
 
         event EventHandler<BandwidthLimitEventArgs> OnBandwidthLimitUpdated;

--- a/src/LiveStreamingServerNet.Rtmp.Client/Internal/Contracts/IRtmpSessionContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Internal/Contracts/IRtmpSessionContext.cs
@@ -1,6 +1,7 @@
 ﻿using LiveStreamingServerNet.Networking.Contracts;
 using LiveStreamingServerNet.Rtmp.Client.Contracts;
 using LiveStreamingServerNet.Rtmp.Internal.Contracts;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using System.Collections.Concurrent;
 
 namespace LiveStreamingServerNet.Rtmp.Client.Internal.Contracts
@@ -30,9 +31,9 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal.Contracts
         List<IRtmpStreamContext> GetStreamContexts();
         IRtmpStreamContext? GetStreamContext(uint streamId);
         void RemoveStreamContext(uint streamId);
+        void Recycle(IDataBufferPool dataBufferPool);
 
         event EventHandler<BandwidthLimitEventArgs> OnBandwidthLimitUpdated;
+
     }
-
-
 }

--- a/src/LiveStreamingServerNet.Rtmp.Client/Internal/HostRtmpClient.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Internal/HostRtmpClient.cs
@@ -36,8 +36,8 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
         public void Stop()
             => _innerClient.Stop();
 
-        public Task UntilStoppedAsync()
-            => _innerClient.UntilStoppedAsync();
+        public Task UntilStoppedAsync(CancellationToken cancellationToken)
+            => _innerClient.UntilStoppedAsync(cancellationToken);
 
         public async ValueTask DisposeAsync()
             => await _serviceProvider.DisposeAsync();

--- a/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpClient.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpClient.cs
@@ -9,6 +9,7 @@ using LiveStreamingServerNet.Rtmp.Client.Internal.Logging;
 using LiveStreamingServerNet.Rtmp.Client.Internal.Services.Contracts;
 using LiveStreamingServerNet.Rtmp.Internal;
 using LiveStreamingServerNet.Utilities.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Diagnostics;
@@ -226,11 +227,11 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
             catch (ObjectDisposedException) { }
         }
 
-        public async Task UntilStoppedAsync()
+        public async Task UntilStoppedAsync(CancellationToken cancellationToken)
         {
             if (_clientTask != null)
             {
-                await _clientTask;
+                await _clientTask.WithCancellation(cancellationToken);
             }
         }
 
@@ -268,9 +269,12 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
                 _clientCts.Cancel();
             }
 
-            _clientCts.Dispose();
+            if (_clientTask != null)
+            {
+                await _clientTask;
+            }
 
-            await UntilStoppedAsync();
+            _clientCts.Dispose();
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpSessionContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpSessionContext.cs
@@ -3,6 +3,7 @@ using LiveStreamingServerNet.Rtmp.Client.Contracts;
 using LiveStreamingServerNet.Rtmp.Client.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Internal;
 using LiveStreamingServerNet.Rtmp.Internal.Contracts;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using System.Collections.Concurrent;
 
 namespace LiveStreamingServerNet.Rtmp.Client.Internal
@@ -84,6 +85,12 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
         {
             _bandwidthLimit = value;
             OnBandwidthLimitUpdated?.Invoke(this, new BandwidthLimitEventArgs(value));
+        }
+
+        public void Recycle(IDataBufferPool dataBufferPool)
+        {
+            foreach (var chunkStreamContext in _chunkStreamContexts.Values)
+                chunkStreamContext.RecyclePayload(dataBufferPool);
         }
 
         public ValueTask DisposeAsync()

--- a/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpSessionHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpSessionHandler.cs
@@ -3,6 +3,7 @@ using LiveStreamingServerNet.Rtmp.Client.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Client.Internal.Logging;
 using LiveStreamingServerNet.Rtmp.Client.Internal.RtmpEvents;
 using LiveStreamingServerNet.Rtmp.Internal;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.Common;
 using LiveStreamingServerNet.Utilities.Common.Contracts;
 using LiveStreamingServerNet.Utilities.Mediators.Contracts;
@@ -15,6 +16,7 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
         private readonly IRtmpSessionContext _context;
         private readonly IRtmpClientContext _clientContext;
         private readonly IMediator _mediator;
+        private readonly IDataBufferPool _dataBufferPool;
         private readonly ILogger _logger;
         private readonly IPool<RtmpChunkEvent> _rtmpChunkEventPool;
 
@@ -22,11 +24,13 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
             IRtmpSessionContext context,
             IRtmpClientContext clientContext,
             IMediator mediator,
+            IDataBufferPool dataBufferPool,
             ILogger<RtmpSessionHandler> logger)
         {
             _context = context;
             _clientContext = clientContext;
             _mediator = mediator;
+            _dataBufferPool = dataBufferPool;
             _logger = logger;
             _rtmpChunkEventPool = new Pool<RtmpChunkEvent>(() => new RtmpChunkEvent());
         }
@@ -102,6 +106,7 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
 
         public async ValueTask DisposeAsync()
         {
+            _context.Recycle(_dataBufferPool);
             await _context.DisposeAsync();
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpSessionHandlerFactory.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Client/Internal/RtmpSessionHandlerFactory.cs
@@ -1,5 +1,6 @@
 ﻿using LiveStreamingServerNet.Networking.Contracts;
 using LiveStreamingServerNet.Rtmp.Client.Internal.Contracts;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.Mediators.Contracts;
 using Microsoft.Extensions.Logging;
 
@@ -9,17 +10,20 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
     {
         private readonly IRtmpClientContext _clientContext;
         private readonly IMediator _mediator;
+        private readonly IDataBufferPool _dataBufferPool;
         private readonly IRtmpSessionContextFactory _contextFactory;
         private readonly ILogger<RtmpSessionHandler> _logger;
 
         public RtmpSessionHandlerFactory(
             IRtmpClientContext clientContext,
             IMediator mediator,
+            IDataBufferPool dataBufferPool,
             IRtmpSessionContextFactory contextFactory,
             ILogger<RtmpSessionHandler> logger)
         {
             _clientContext = clientContext;
             _mediator = mediator;
+            _dataBufferPool = dataBufferPool;
             _contextFactory = contextFactory;
             _logger = logger;
         }
@@ -27,7 +31,7 @@ namespace LiveStreamingServerNet.Rtmp.Client.Internal
         public ISessionHandler Create(ISessionHandle session)
         {
             var context = _contextFactory.Create(session);
-            return new RtmpSessionHandler(context, _clientContext, _mediator, _logger);
+            return new RtmpSessionHandler(context, _clientContext, _mediator, _dataBufferPool, _logger);
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Contracts/IRtmpDownstreamSubscriber.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Contracts/IRtmpDownstreamSubscriber.cs
@@ -1,0 +1,7 @@
+﻿namespace LiveStreamingServerNet.Rtmp.Relay.Contracts
+{
+    public interface IRtmpDownstreamSubscriber : IDisposable
+    {
+        string StreamPath { get; }
+    }
+}

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Contracts/IRtmpRelayManager.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Contracts/IRtmpRelayManager.cs
@@ -1,0 +1,7 @@
+﻿namespace LiveStreamingServerNet.Rtmp.Relay.Contracts
+{
+    public interface IRtmpRelayManager
+    {
+        Task<IRtmpDownstreamSubscriber?> RequestDownstreamAsync(string streamPath, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Installer/RtmpServerConfiguratorExtensions.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Installer/RtmpServerConfiguratorExtensions.cs
@@ -41,6 +41,8 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Installer
 
         private static void AddRtmpRelay(IServiceCollection services)
         {
+            services.TryAddSingleton<IRtmpRelayManager, RtmpRelayManager>();
+
             AddRtmpUpstreamRelay(services);
             AddRtmpDownstreamRelay(services);
         }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Contracts/IRtmpDownstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Contracts/IRtmpDownstreamProcess.cs
@@ -1,9 +1,12 @@
-﻿namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Contracts
+﻿using LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts;
+
+namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Contracts
 {
-    internal interface IRtmpDownstreamProcess
+    internal interface IRtmpDownstreamProcess : IAsyncDisposable
     {
         string StreamPath { get; }
 
+        ValueTask<PublishingStreamResult> InitializeAsync(CancellationToken cancellationToken);
         Task RunAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Contracts/IRtmpUpstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Contracts/IRtmpUpstreamProcess.cs
@@ -2,7 +2,7 @@
 
 namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Contracts
 {
-    internal interface IRtmpUpstreamProcess
+    internal interface IRtmpUpstreamProcess : IAsyncDisposable
     {
         string StreamPath { get; }
         IReadOnlyDictionary<string, string> StreamArguments { get; }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Contracts/IRtmpUpstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Contracts/IRtmpUpstreamProcess.cs
@@ -9,5 +9,6 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Contracts
 
         Task RunAsync(CancellationToken cancellationToken);
         void OnReceiveMediaData(MediaType mediaType, IRentedBuffer rentedBuffer, uint timestamp, bool isSkippable);
+        void OnReceiveMetaData(IReadOnlyDictionary<string, object> metaData);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Logging/LoggerExtensions.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Logging/LoggerExtensions.cs
@@ -15,6 +15,9 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Logging
         [LoggerMessage(LogLevel.Information, "Downstream idle timeout (StreamPath={StreamPath})")]
         public static partial void RtmpDownstreamIdleTimeout(this ILogger logger, string streamPath);
 
+        [LoggerMessage(LogLevel.Error, "The origin for the downstream could not be resolved (StreamPath={StreamPath})")]
+        public static partial void RtmpDownstreamOriginNotResolved(this ILogger logger, string streamPath);
+
         [LoggerMessage(LogLevel.Information, "Downstream origin resolved (StreamPath={StreamPath}, RtmpOrigin={Origin})")]
         public static partial void RtmpDownstreamOriginResolved(this ILogger logger, string streamPath, RtmpOrigin origin);
 
@@ -39,6 +42,9 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Logging
         [LoggerMessage(LogLevel.Information, "Upstream idle timeout (StreamPath={StreamPath})")]
         public static partial void RtmpUpstreamIdleTimeout(this ILogger logger, string streamPath);
 
+        [LoggerMessage(LogLevel.Error, "The origin for the upstream could not be resolved (StreamPath={StreamPath})")]
+        public static partial void RtmpUpstreamOriginNotResolved(this ILogger logger, string streamPath);
+
         [LoggerMessage(LogLevel.Information, "Upstream origin resolved (StreamPath={StreamPath}, RtmpOrigin={Origin})")]
         public static partial void RtmpUpstreamOriginResolved(this ILogger logger, string streamPath, RtmpOrigin origin);
 
@@ -59,5 +65,11 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Logging
 
         [LoggerMessage(LogLevel.Debug, "End upstream media packet discard (StreamPath={StreamPath}, OutstandingSize={OutstandingSize}, OutstandingCount={OutstandingCount})")]
         public static partial void EndUpstreamMediaPacketDiscard(this ILogger logger, string streamPath, long outstandingSize, long outstandingCount);
+
+        [LoggerMessage(LogLevel.Error, "An error occurred while initializing the downstream (StreamPath={StreamPath})")]
+        public static partial void RtmpDownstreamInitializationError(this ILogger logger, string streamPath, Exception ex);
+
+        [LoggerMessage(LogLevel.Error, "An error occurred while resolving the origin for the upstream (StreamPath={StreamPath})")]
+        public static partial void RtmpUpstreamOriginResolveError(this ILogger logger, string streamPath, Exception ex);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcess.cs
@@ -69,6 +69,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             if (initialized)
                 throw new InvalidOperationException("The process has already been initialized.");
 
+
             try
             {
                 var publishStreamContext = CreatePublishStreamContext();
@@ -404,6 +405,8 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
                 .Select(subscriber => subscriber.StreamContext)
                 .Select(streamContext => _streamDeletion.DeleteStreamAsync(streamContext).AsTask())
             );
+
+            _publishStreamContext.Dispose();
         }
 
         private record struct StreamData(MediaData? MediaData, MetaData? MetaData)

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcess.cs
@@ -60,9 +60,9 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
         public async Task RunAsync(CancellationToken cancellationToken)
         {
             var publishStreamContext = CreatePublishStreamContext();
-            var publishingResult = _streamManager.StartDirectPublishing(publishStreamContext, out _);
+            var publishingResult = await _streamManager.StartDirectPublishingAsync(publishStreamContext);
 
-            if (publishingResult != PublishingStreamResult.Succeeded)
+            if (publishingResult.Result != PublishingStreamResult.Succeeded)
                 return;
 
             try
@@ -75,9 +75,9 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             }
             finally
             {
-                _streamManager.StopPublishing(publishStreamContext, out var subscribers);
+                var stopPublishingResult = await _streamManager.StopPublishingAsync(publishStreamContext);
 
-                await Task.WhenAll(subscribers
+                await Task.WhenAll(stopPublishingResult.SubscribeStreamContexts
                     .Select(subscriber => subscriber.StreamContext)
                     .Select(streamContext => _streamDeletion.DeleteStreamAsync(streamContext).AsTask())
                 );

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcess.cs
@@ -163,7 +163,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
                 rtmpStream.Subscribe.Play(origin.StreamName);
 
                 _logger.RtmpDownstreamCreated(_streamPath);
-                await rtmpClient.UntilStoppedAsync();
+                await rtmpClient.UntilStoppedAsync(abortCts.Token);
             }
             catch (OperationCanceledException) when (abortCts.IsCancellationRequested) { }
             catch (Exception)

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcessFactory.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamProcessFactory.cs
@@ -14,6 +14,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
         private readonly IRtmpStreamDeletionService _streamDeletion;
         private readonly IRtmpVideoDataProcessorService _videoDataProcessor;
         private readonly IRtmpAudioDataProcessorService _audioDataProcessor;
+        private readonly IRtmpMetaDataProcessorService _metaDataProcessor;
         private readonly IRtmpOriginResolver _originResolver;
         private readonly IBufferPool _bufferPool;
         private readonly IDataBufferPool _dataBufferPool;
@@ -25,6 +26,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             IRtmpStreamDeletionService streamDeletion,
             IRtmpVideoDataProcessorService videoDataProcessor,
             IRtmpAudioDataProcessorService audioDataProcessor,
+            IRtmpMetaDataProcessorService metaDataProcessor,
             IRtmpOriginResolver originResolver,
             IBufferPool bufferPool,
             IDataBufferPool dataBufferPool,
@@ -35,6 +37,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             _streamDeletion = streamDeletion;
             _videoDataProcessor = videoDataProcessor;
             _audioDataProcessor = audioDataProcessor;
+            _metaDataProcessor = metaDataProcessor;
             _originResolver = originResolver;
             _bufferPool = bufferPool;
             _dataBufferPool = dataBufferPool;
@@ -50,6 +53,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
                 _streamDeletion,
                 _videoDataProcessor,
                 _audioDataProcessor,
+                _metaDataProcessor,
                 _originResolver,
                 _bufferPool,
                 _dataBufferPool,

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamSubscriber.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpDownstreamSubscriber.cs
@@ -1,0 +1,28 @@
+﻿using LiveStreamingServerNet.Rtmp.Relay.Contracts;
+
+namespace LiveStreamingServerNet.Rtmp.Relay.Internal
+{
+    internal class RtmpDownstreamSubscriber : IRtmpDownstreamSubscriber
+    {
+        public string StreamPath { get; }
+
+        private readonly Action<IRtmpDownstreamSubscriber> _disposeCallback;
+        private bool _disposed;
+
+
+        public RtmpDownstreamSubscriber(string streamPath, Action<IRtmpDownstreamSubscriber> disposeCallback)
+        {
+            StreamPath = streamPath;
+            _disposeCallback = disposeCallback;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _disposeCallback(this);
+        }
+    }
+}

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpRelayManager.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpRelayManager.cs
@@ -1,0 +1,20 @@
+﻿using LiveStreamingServerNet.Rtmp.Relay.Contracts;
+using LiveStreamingServerNet.Rtmp.Relay.Internal.Services.Contracts;
+
+namespace LiveStreamingServerNet.Rtmp.Relay.Internal
+{
+    internal class RtmpRelayManager : IRtmpRelayManager
+    {
+        private readonly IRtmpDownstreamManagerService _downstreamManager;
+
+        public RtmpRelayManager(IRtmpDownstreamManagerService downstreamManager)
+        {
+            _downstreamManager = downstreamManager;
+        }
+
+        public Task<IRtmpDownstreamSubscriber?> RequestDownstreamAsync(string streamPath, CancellationToken cancellationToken = default)
+        {
+            return _downstreamManager.RequestDownstreamAsync(streamPath);
+        }
+    }
+}

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpUpstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpUpstreamProcess.cs
@@ -28,7 +28,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
         private readonly IReadOnlyDictionary<string, string> _streamArguments;
         private readonly IRtmpPublishStreamContext _publishStreamContext;
         private readonly IRtmpOriginResolver _originResolver;
-        private readonly IRtmpStreamDeletionService _streamDeletion;
+        private readonly IRtmpStreamManagerService _streamManager;
         private readonly IBufferPool _bufferPool;
         private readonly IDataBufferPool _dataBufferPool;
         private readonly RtmpUpstreamConfiguration _config;
@@ -50,7 +50,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
         public RtmpUpstreamProcess(
             IRtmpPublishStreamContext publishStreamContext,
             IRtmpOriginResolver originResolver,
-            IRtmpStreamDeletionService streamDeletion,
+            IRtmpStreamManagerService streamManager,
             IBufferPool bufferPool,
             IDataBufferPool dataBufferPool,
             IUpstreamMediaPacketDiscarderFactory packetDiscarderFactory,
@@ -61,7 +61,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             _streamArguments = publishStreamContext.StreamArguments;
             _publishStreamContext = publishStreamContext;
             _originResolver = originResolver;
-            _streamDeletion = streamDeletion;
+            _streamManager = streamManager;
             _bufferPool = bufferPool;
             _dataBufferPool = dataBufferPool;
             _config = config.Value;
@@ -144,7 +144,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
 
             try
             {
-                await _streamDeletion.DeleteStreamAsync(_publishStreamContext.StreamContext);
+                await _streamManager.StopPublishingAsync(_publishStreamContext);
                 await _publishStreamContext.StreamContext.ClientContext.Client.DisconnectAsync(abortCts.Token);
             }
             catch (OperationCanceledException) when (abortCts.IsCancellationRequested) { }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpUpstreamProcess.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpUpstreamProcess.cs
@@ -106,11 +106,11 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
 
                 SubscribeToStreamEvents(rtmpStream, idleChecker, abortCts);
 
-                var mediaDataSendingTask = StreamDataSendingTask(rtmpStream, idleChecker, abortCts);
+                var streamDataSendingTask = StreamDataSendingTask(rtmpStream, idleChecker, abortCts);
                 rtmpStream.Publish.Publish(origin.StreamName);
 
                 _logger.RtmpUpstreamCreated(_streamPath);
-                var completedTask = await Task.WhenAny(rtmpClient.UntilStoppedAsync(abortCts.Token), mediaDataSendingTask);
+                var completedTask = await Task.WhenAny(rtmpClient.UntilStoppedAsync(abortCts.Token), streamDataSendingTask);
                 await completedTask;
             }
             catch (OperationCanceledException) when (abortCts.IsCancellationRequested) { }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpUpstreamProcessFactory.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/RtmpUpstreamProcessFactory.cs
@@ -13,7 +13,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
     internal class RtmpUpstreamProcessFactory : IRtmpUpstreamProcessFactory
     {
         private readonly IRtmpOriginResolver _originResolver;
-        private readonly IRtmpStreamDeletionService _streamDeletion;
+        private readonly IRtmpStreamManagerService _streamManager;
         private readonly IBufferPool _bufferPool;
         private readonly IDataBufferPool _dataBufferPool;
         private readonly IUpstreamMediaPacketDiscarderFactory _packetDiscarderFactory;
@@ -22,7 +22,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
 
         public RtmpUpstreamProcessFactory(
             IRtmpOriginResolver originResolver,
-            IRtmpStreamDeletionService streamDeletion,
+            IRtmpStreamManagerService streamManager,
             IBufferPool bufferPool,
             IDataBufferPool dataBufferPool,
             IUpstreamMediaPacketDiscarderFactory packetDiscarderFactory,
@@ -30,7 +30,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             ILogger<RtmpUpstreamProcess> logger)
         {
             _originResolver = originResolver;
-            _streamDeletion = streamDeletion;
+            _streamManager = streamManager;
             _bufferPool = bufferPool;
             _dataBufferPool = dataBufferPool;
             _packetDiscarderFactory = packetDiscarderFactory;
@@ -43,7 +43,7 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal
             return new RtmpUpstreamProcess(
                 publishStreamContext,
                 _originResolver,
-                _streamDeletion,
+                _streamManager,
                 _bufferPool,
                 _dataBufferPool,
                 _packetDiscarderFactory,

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/Contracts/IRtmpDownstreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/Contracts/IRtmpDownstreamManagerService.cs
@@ -1,6 +1,9 @@
-﻿namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services.Contracts
+﻿using LiveStreamingServerNet.Rtmp.Relay.Contracts;
+
+namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services.Contracts
 {
     internal interface IRtmpDownstreamManagerService
     {
+        Task<IRtmpDownstreamSubscriber?> RequestDownstreamAsync(string streamPath);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpDownstreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpDownstreamManagerService.cs
@@ -176,6 +176,9 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services
                 if (_streamManager.IsStreamBeingSubscribed(streamPath))
                     return;
 
+                if (_downstreamSubscribers.ContainsKey(streamPath))
+                    return;
+
                 downstreamProcessTaskItem.Cts.Cancel();
             }
         }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpUpstreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpUpstreamManagerService.cs
@@ -116,6 +116,11 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services
             return ValueTask.CompletedTask;
         }
 
+        public bool FilterMediaMessage(string streamPath, MediaType mediaType, uint timestamp, bool isSkippable)
+        {
+            return _upstreamProcessTasks.ContainsKey(streamPath);
+        }
+
         public ValueTask OnReceiveMediaMessageAsync(string streamPath, MediaType mediaType, IRentedBuffer rentedBuffer, uint timestamp, bool isSkippable)
         {
             if (_upstreamProcessTasks.TryGetValue(streamPath, out var upstreamProcessTaskItem))
@@ -128,11 +133,17 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services
 
         public ValueTask OnRtmpStreamPublishedAsync(IEventContext context, uint clientId, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
         {
+            if (clientId == 0)
+                return ValueTask.CompletedTask;
+
             return CreateUpstreamProcessIfNeededAsync(streamPath);
         }
 
         public ValueTask OnRtmpStreamUnpublishedAsync(IEventContext context, uint clientId, string streamPath)
         {
+            if (clientId == 0)
+                return ValueTask.CompletedTask;
+
             RemoveUpstreamProcessIfNeeded(streamPath);
             return ValueTask.CompletedTask;
         }

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpUpstreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpUpstreamManagerService.cs
@@ -1,5 +1,4 @@
-﻿using LiveStreamingServerNet.Rtmp.Client.Contracts;
-using LiveStreamingServerNet.Rtmp.Relay.Configurations;
+﻿using LiveStreamingServerNet.Rtmp.Relay.Configurations;
 using LiveStreamingServerNet.Rtmp.Relay.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Relay.Internal.Services.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Contracts;

--- a/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpUpstreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Relay/Internal/Services/RtmpUpstreamManagerService.cs
@@ -138,6 +138,16 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services
             return ValueTask.CompletedTask;
         }
 
+        public ValueTask OnRtmpStreamMetaDataReceivedAsync(IEventContext context, uint clientId, string streamPath, IReadOnlyDictionary<string, object> metaData)
+        {
+            if (_upstreamProcessTasks.TryGetValue(streamPath, out var upstreamProcessTaskItem))
+            {
+                upstreamProcessTaskItem.UpstreamProcess.OnReceiveMetaData(metaData);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
         public ValueTask OnRtmpStreamPublishedAsync(IEventContext context, uint clientId, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
         {
             if (clientId == 0)
@@ -159,9 +169,6 @@ namespace LiveStreamingServerNet.Rtmp.Relay.Internal.Services
             => ValueTask.CompletedTask;
 
         public ValueTask OnRtmpStreamUnsubscribedAsync(IEventContext context, uint clientId, string streamPath)
-            => ValueTask.CompletedTask;
-
-        public ValueTask OnRtmpStreamMetaDataReceivedAsync(IEventContext context, uint clientId, string streamPath, IReadOnlyDictionary<string, object> metaData)
             => ValueTask.CompletedTask;
 
         private record UpstreamProcessItem(IRtmpUpstreamProcess UpstreamProcess, Task UpsteramProcessTask, CancellationTokenSource Cts);

--- a/src/LiveStreamingServerNet.Rtmp.Server/Contracts/IRtmpMediaCachingInterceptor.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Contracts/IRtmpMediaCachingInterceptor.cs
@@ -4,6 +4,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Contracts
 {
     public interface IRtmpMediaCachingInterceptor
     {
+        bool FilterCache(string streamPath, MediaType mediaType) => true;
         ValueTask OnCacheSequenceHeaderAsync(string streamPath, MediaType mediaType, byte[] sequenceHeader);
         ValueTask OnCachePictureAsync(string streamPath, MediaType mediaType, IRentedBuffer rentedBuffer, uint timestamp);
         ValueTask OnClearGroupOfPicturesCacheAsync(string streamPath);

--- a/src/LiveStreamingServerNet.Rtmp.Server/Contracts/IRtmpMediaMessageInterceptor.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Contracts/IRtmpMediaMessageInterceptor.cs
@@ -4,6 +4,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Contracts
 {
     public interface IRtmpMediaMessageInterceptor
     {
+        bool FilterMediaMessage(string streamPath, MediaType mediaType, uint timestamp, bool isSkippable) => true;
         ValueTask OnReceiveMediaMessageAsync(string streamPath, MediaType mediaType, IRentedBuffer rentedBuffer, uint timestamp, bool isSkippable);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Installer/RtmpServerInstaller.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Installer/RtmpServerInstaller.cs
@@ -75,14 +75,15 @@ namespace LiveStreamingServerNet.Rtmp.Server.Installer
                     .AddSingleton<IRtmpProtocolControlService, RtmpProtocolControlService>()
                     .AddSingleton<IRtmpUserControlMessageSenderService, RtmpUserControlMessageSenderService>()
                     .AddSingleton<IRtmpCommandMessageSenderService, RtmpCommandMessageSenderService>()
-                    .AddSingleton<IRtmpMediaMessageCacherService, RtmpMediaMessageCacherService>()
+                    .AddSingleton<IRtmpCacherService, RtmpCacherService>()
                     .AddSingleton<IRtmpMediaMessageBroadcasterService, RtmpMediaMessageBroadcasterService>()
                     .AddSingleton<IRtmpStreamDeletionService, RtmpStreamDeletionService>()
                     .AddSingleton<IRtmpMediaMessageInterceptionService, RtmpMediaMessageInterceptionService>()
                     .AddSingleton<IRtmpMediaCachingInterceptionService, RtmpMediaCachingInterceptionService>()
                     .AddSingleton<IRtmpAcknowledgementHandlerService, RtmpAcknowledgementHandlerService>()
                     .AddSingleton<IRtmpVideoDataProcessorService, RtmpVideoDataProcessorService>()
-                    .AddSingleton<IRtmpAudioDataProcessorService, RtmpAudioDataProcessorService>();
+                    .AddSingleton<IRtmpAudioDataProcessorService, RtmpAudioDataProcessorService>()
+                    .AddSingleton<IRtmpMetaDataProcessorService, RtmpMetaDataProcessorService>();
 
             services.AddSingleton<IRtmpStreamInfoManager, RtmpStreamInfoManager>();
 

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpClientSessionContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpClientSessionContext.cs
@@ -1,6 +1,7 @@
 ﻿using LiveStreamingServerNet.Networking.Contracts;
 using LiveStreamingServerNet.Rtmp.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEventHandlers.Handshakes;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using System.Collections.Concurrent;
 
 namespace LiveStreamingServerNet.Rtmp.Server.Internal.Contracts
@@ -29,5 +30,6 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Contracts
         List<IRtmpStreamContext> GetStreamContexts();
         IRtmpStreamContext? GetStreamContext(uint streamId);
         void RemoveStreamContext(uint streamId);
+        void Recycle(IDataBufferPool dataBufferPool);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpServerEventDispatcher.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpServerEventDispatcher.cs
@@ -11,11 +11,11 @@
 
     internal interface IRtmpServerStreamEventDispatcher
     {
-        ValueTask RtmpStreamPublishedAsync(IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments);
-        ValueTask RtmpStreamUnpublishedAsync(IRtmpClientSessionContext clientContext, string streamPath);
-        ValueTask RtmpStreamSubscribedAsync(IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments);
-        ValueTask RtmpStreamUnsubscribedAsync(IRtmpClientSessionContext clientContext, string streamPath);
+        ValueTask RtmpStreamPublishedAsync(IRtmpPublishStreamContext publishStreamContext);
+        ValueTask RtmpStreamUnpublishedAsync(IRtmpPublishStreamContext publishStreamContext);
+        ValueTask RtmpStreamMetaDataReceivedAsync(IRtmpPublishStreamContext publishStreamContext);
 
-        ValueTask RtmpStreamMetaDataReceivedAsync(IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, object> metaData);
+        ValueTask RtmpStreamSubscribedAsync(IRtmpSubscribeStreamContext subscribeStreamContext);
+        ValueTask RtmpStreamUnsubscribedAsync(IRtmpSubscribeStreamContext subscribeStreamContext);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpServerEventHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpServerEventHandler.cs
@@ -17,11 +17,11 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Contracts
     {
         int GetOrder() => 0;
 
-        ValueTask OnRtmpStreamPublishedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments);
-        ValueTask OnRtmpStreamUnpublishedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath);
-        ValueTask OnRtmpStreamSubscribedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments);
-        ValueTask OnRtmpStreamUnsubscribedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath);
+        ValueTask OnRtmpStreamPublishedAsync(IEventContext context, IRtmpPublishStreamContext publishStreamContext);
+        ValueTask OnRtmpStreamUnpublishedAsync(IEventContext context, IRtmpPublishStreamContext publishStreamContext);
+        ValueTask OnRtmpStreamMetaDataReceivedAsync(IEventContext context, IRtmpPublishStreamContext publishStreamContext);
 
-        ValueTask OnRtmpStreamMetaDataReceivedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, object> metaData);
+        ValueTask OnRtmpStreamSubscribedAsync(IEventContext context, IRtmpSubscribeStreamContext subscribeStreamContext);
+        ValueTask OnRtmpStreamUnsubscribedAsync(IEventContext context, IRtmpSubscribeStreamContext subscribeStreamContext);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpStreamContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Contracts/IRtmpStreamContext.cs
@@ -56,7 +56,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Contracts
         bool IsReceivingVideo { get; set; }
 
         void CompleteInitialization();
-        Task UntilInitializationCompleteAsync();
+        Task UntilInitializationCompleteAsync(CancellationToken cancellationToken = default);
     }
 
     internal interface IGroupOfPicturesCache : IDisposable

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpClientSessionContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpClientSessionContext.cs
@@ -79,6 +79,12 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
                 streamContext.Dispose();
         }
 
+        public void Recycle(IDataBufferPool dataBufferPool)
+        {
+            foreach (var chunkStreamContext in _chunkStreamContexts.Values)
+                chunkStreamContext.RecyclePayload(dataBufferPool);
+        }
+
         public ValueTask DisposeAsync()
         {
             foreach (var streamContext in _streamContexts.Values)

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpClientSessionHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpClientSessionHandler.cs
@@ -4,6 +4,7 @@ using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Internal.Logging;
 using LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEvents;
 using LiveStreamingServerNet.Rtmp.Server.RateLimiting.Contracts;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.Common;
 using LiveStreamingServerNet.Utilities.Common.Contracts;
 using LiveStreamingServerNet.Utilities.Mediators.Contracts;
@@ -15,6 +16,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
     {
         private readonly IRtmpClientSessionContext _clientContext;
         private readonly IMediator _mediator;
+        private readonly IDataBufferPool _dataBufferPool;
         private readonly IRtmpServerConnectionEventDispatcher _eventDispatcher;
         private readonly ILogger _logger;
         private readonly IBandwidthLimiter? _bandwidthLimiter;
@@ -23,12 +25,14 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
         public RtmpClientSessionHandler(
             IRtmpClientSessionContext clientContext,
             IMediator mediator,
+            IDataBufferPool dataBufferPool,
             IRtmpServerConnectionEventDispatcher eventDispatcher,
             ILogger<RtmpClientSessionHandler> logger,
             IBandwidthLimiterFactory? bandwidthLimiterFactory = null)
         {
             _clientContext = clientContext;
             _mediator = mediator;
+            _dataBufferPool = dataBufferPool;
             _eventDispatcher = eventDispatcher;
             _logger = logger;
             _bandwidthLimiter = bandwidthLimiterFactory?.Create();
@@ -112,6 +116,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
             if (_bandwidthLimiter != null)
                 await _bandwidthLimiter.DisposeAsync();
 
+            _clientContext.Recycle(_dataBufferPool);
             await _clientContext.DisposeAsync();
         }
 

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpClientSessionHandlerFactory.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpClientSessionHandlerFactory.cs
@@ -1,6 +1,7 @@
 ﻿using LiveStreamingServerNet.Networking.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.RateLimiting.Contracts;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.Mediators.Contracts;
 using Microsoft.Extensions.Logging;
 
@@ -9,6 +10,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
     internal class RtmpClientSessionHandlerFactory : ISessionHandlerFactory
     {
         private readonly IMediator _mediator;
+        private readonly IDataBufferPool _dataBufferPool;
         private readonly IRtmpServerConnectionEventDispatcher _eventDispatcher;
         private readonly IRtmpClientSessionContextFactory _clientContextFactory;
         private readonly ILogger<RtmpClientSessionHandler> _logger;
@@ -16,12 +18,14 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
 
         public RtmpClientSessionHandlerFactory(
             IMediator mediator,
+            IDataBufferPool dataBufferPool,
             IRtmpServerConnectionEventDispatcher eventDispatcher,
             IRtmpClientSessionContextFactory clientContextFactory,
             ILogger<RtmpClientSessionHandler> logger,
             IBandwidthLimiterFactory? bandwidthLimiterFactory = null)
         {
             _mediator = mediator;
+            _dataBufferPool = dataBufferPool;
             _eventDispatcher = eventDispatcher;
             _clientContextFactory = clientContextFactory;
             _logger = logger;
@@ -31,7 +35,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
         public ISessionHandler Create(ISessionHandle client)
         {
             var clientContext = _clientContextFactory.Create(client);
-            return new RtmpClientSessionHandler(clientContext, _mediator, _eventDispatcher, _logger, _bandwidthLimiterFactory);
+            return new RtmpClientSessionHandler(clientContext, _mediator, _dataBufferPool, _eventDispatcher, _logger, _bandwidthLimiterFactory);
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpEventHandlers/Commands/RtmpPlayCommandHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpEventHandlers/Commands/RtmpPlayCommandHandler.cs
@@ -21,7 +21,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEventHandlers.Commands
         private readonly IRtmpStreamManagerService _streamManager;
         private readonly IRtmpCommandMessageSenderService _commandMessageSender;
         private readonly IRtmpUserControlMessageSenderService _userControlMessageSender;
-        private readonly IRtmpMediaMessageCacherService _mediaMessageCacher;
+        private readonly IRtmpCacherService _cacher;
         private readonly IStreamAuthorization _streamAuthorization;
         private readonly ILogger<RtmpPlayCommandHandler> _logger;
 
@@ -29,14 +29,14 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEventHandlers.Commands
             IRtmpStreamManagerService streamManager,
             IRtmpCommandMessageSenderService commandMessageSender,
             IRtmpUserControlMessageSenderService userControlMessageSender,
-            IRtmpMediaMessageCacherService mediaMessageCacher,
+            IRtmpCacherService cacher,
             IStreamAuthorization streamAuthorization,
             ILogger<RtmpPlayCommandHandler> logger)
         {
             _streamManager = streamManager;
             _commandMessageSender = commandMessageSender;
             _userControlMessageSender = userControlMessageSender;
-            _mediaMessageCacher = mediaMessageCacher;
+            _cacher = cacher;
             _streamAuthorization = streamAuthorization;
             _logger = logger;
         }
@@ -136,16 +136,16 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEventHandlers.Commands
             if (streamContext.SubscribeContext == null || publishStreamContext == null)
                 return;
 
-            _mediaMessageCacher.SendCachedStreamMetaDataMessage(
+            _cacher.SendCachedStreamMetaDataMessage(
                 streamContext.SubscribeContext, publishStreamContext,
                 chunkStreamContext.Timestamp);
 
-            _mediaMessageCacher.SendCachedHeaderMessages(
+            _cacher.SendCachedHeaderMessages(
                 streamContext.SubscribeContext, publishStreamContext);
 
             if (publishStreamContext.GroupOfPicturesCacheActivated)
             {
-                _mediaMessageCacher.SendCachedGroupOfPictures(
+                _cacher.SendCachedGroupOfPictures(
                     streamContext.SubscribeContext, publishStreamContext);
             }
         }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpEventHandlers/Data/RtmpDataMessageHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpEventHandlers/Data/RtmpDataMessageHandler.cs
@@ -89,7 +89,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEventHandlers.Data
 
             BroadcastMetaDataToSubscribers(chunkStreamContext, publishStreamContext);
 
-            await _eventDispatcher.RtmpStreamMetaDataReceivedAsync(clientContext, publishStreamContext.StreamPath, metaData);
+            await _eventDispatcher.RtmpStreamMetaDataReceivedAsync(publishStreamContext);
 
             return true;
         }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpServerEventDispatcher.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpServerEventDispatcher.cs
@@ -103,78 +103,78 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
             return _eventHandlers;
         }
 
-        public async ValueTask RtmpStreamMetaDataReceivedAsync(IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, object> metaData)
+        public async ValueTask RtmpStreamMetaDataReceivedAsync(IRtmpPublishStreamContext publishStreamContext)
         {
             try
             {
                 using var context = EventContext.Obtain();
 
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamMetaDataReceivedAsync(context, clientContext, streamPath, metaData);
+                    await eventHandler.OnRtmpStreamMetaDataReceivedAsync(context, publishStreamContext);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamMetaDataReceivedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamMetaDataReceivedEventError(publishStreamContext?.StreamContext?.ClientContext.Client.Id ?? 0, ex);
             }
         }
 
-        public async ValueTask RtmpStreamPublishedAsync(IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
+        public async ValueTask RtmpStreamPublishedAsync(IRtmpPublishStreamContext publishStreamContext)
         {
             try
             {
                 using var context = EventContext.Obtain();
 
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamPublishedAsync(context, clientContext, streamPath, streamArguments);
+                    await eventHandler.OnRtmpStreamPublishedAsync(context, publishStreamContext);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamPublishedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamPublishedEventError(publishStreamContext?.StreamContext?.ClientContext.Client.Id ?? 0, ex);
             }
         }
 
-        public async ValueTask RtmpStreamSubscribedAsync(IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
+        public async ValueTask RtmpStreamSubscribedAsync(IRtmpSubscribeStreamContext subscribeStreamContext)
         {
             try
             {
                 using var context = EventContext.Obtain();
 
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamSubscribedAsync(context, clientContext, streamPath, streamArguments);
+                    await eventHandler.OnRtmpStreamSubscribedAsync(context, subscribeStreamContext);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamSubscribedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamSubscribedEventError(subscribeStreamContext.StreamContext.ClientContext.Client.Id, ex);
             }
         }
 
-        public async ValueTask RtmpStreamUnpublishedAsync(IRtmpClientSessionContext clientContext, string streamPath)
+        public async ValueTask RtmpStreamUnpublishedAsync(IRtmpPublishStreamContext publishStreamContext)
         {
             try
             {
                 using var context = EventContext.Obtain();
 
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamUnpublishedAsync(context, clientContext, streamPath);
+                    await eventHandler.OnRtmpStreamUnpublishedAsync(context, publishStreamContext);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamUnpublishedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamUnpublishedEventError(publishStreamContext?.StreamContext?.ClientContext.Client.Id ?? 0, ex);
             }
         }
 
-        public async ValueTask RtmpStreamUnsubscribedAsync(IRtmpClientSessionContext clientContext, string streamPath)
+        public async ValueTask RtmpStreamUnsubscribedAsync(IRtmpSubscribeStreamContext subscribeStreamContext)
         {
             try
             {
                 using var context = EventContext.Obtain();
 
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamUnsubscribedAsync(context, clientContext, streamPath);
+                    await eventHandler.OnRtmpStreamUnsubscribedAsync(context, subscribeStreamContext);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamUnsubscribedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamUnsubscribedEventError(subscribeStreamContext.StreamContext.ClientContext.Client.Id, ex);
             }
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpServerEventHandlers/RtmpExternalServerEventDispatcher.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpServerEventHandlers/RtmpExternalServerEventDispatcher.cs
@@ -97,68 +97,82 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.RtmpServerEventHandlers
             return _eventHandlers;
         }
 
-        public async ValueTask OnRtmpStreamMetaDataReceivedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, object> metaData)
+        public async ValueTask OnRtmpStreamMetaDataReceivedAsync(IEventContext context, IRtmpPublishStreamContext publishStreamContext)
         {
+            var clientId = publishStreamContext.StreamContext?.ClientContext.Client.Id ?? 0;
+            var streamPath = publishStreamContext.StreamPath;
+            var streamMetaData = publishStreamContext.StreamMetaData != null ?
+                new Dictionary<string, object>(publishStreamContext.StreamMetaData) :
+                new Dictionary<string, object>();
+
             try
             {
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamMetaDataReceivedAsync(context, clientContext.Client.Id, streamPath, metaData);
+                    await eventHandler.OnRtmpStreamMetaDataReceivedAsync(context, clientId, streamPath, streamMetaData);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamMetaDataReceivedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamMetaDataReceivedEventError(clientId, ex);
             }
         }
 
-        public async ValueTask OnRtmpStreamPublishedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
+        public async ValueTask OnRtmpStreamPublishedAsync(IEventContext context, IRtmpPublishStreamContext publishStreamContext)
         {
+            var clientId = publishStreamContext.StreamContext?.ClientContext.Client.Id ?? 0;
+
             try
             {
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamPublishedAsync(context, clientContext.Client.Id, streamPath, streamArguments);
+                    await eventHandler.OnRtmpStreamPublishedAsync(context, clientId, publishStreamContext.StreamPath, publishStreamContext.StreamArguments);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamPublishedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamPublishedEventError(clientId, ex);
             }
         }
 
-        public async ValueTask OnRtmpStreamSubscribedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments)
+        public async ValueTask OnRtmpStreamSubscribedAsync(IEventContext context, IRtmpSubscribeStreamContext subscribeStreamContext)
         {
+            var clientId = subscribeStreamContext.StreamContext.ClientContext.Client.Id;
+
             try
             {
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamSubscribedAsync(context, clientContext.Client.Id, streamPath, streamArguments);
+                    await eventHandler.OnRtmpStreamSubscribedAsync(context, clientId, subscribeStreamContext.StreamPath, subscribeStreamContext.StreamArguments);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamSubscribedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamSubscribedEventError(clientId, ex);
             }
         }
 
-        public async ValueTask OnRtmpStreamUnpublishedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath)
+        public async ValueTask OnRtmpStreamUnpublishedAsync(IEventContext context, IRtmpPublishStreamContext publishStreamContext)
         {
+            var clientId = publishStreamContext.StreamContext?.ClientContext.Client.Id ?? 0;
+
             try
             {
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamUnpublishedAsync(context, clientContext.Client.Id, streamPath);
+                    await eventHandler.OnRtmpStreamUnpublishedAsync(context, clientId, publishStreamContext.StreamPath);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamUnpublishedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamUnpublishedEventError(clientId, ex);
             }
         }
 
-        public async ValueTask OnRtmpStreamUnsubscribedAsync(IEventContext context, IRtmpClientSessionContext clientContext, string streamPath)
+        public async ValueTask OnRtmpStreamUnsubscribedAsync(IEventContext context, IRtmpSubscribeStreamContext subscribeStreamContext)
         {
+            var clientId = subscribeStreamContext.StreamContext.ClientContext.Client.Id;
+
             try
             {
                 foreach (var eventHandler in GetEventHandlers())
-                    await eventHandler.OnRtmpStreamUnsubscribedAsync(context, clientContext.Client.Id, streamPath);
+                    await eventHandler.OnRtmpStreamUnsubscribedAsync(context, clientId, subscribeStreamContext.StreamPath);
             }
             catch (Exception ex)
             {
-                _logger.DispatchingRtmpStreamUnsubscribedEventError(clientContext.Client.Id, ex);
+                _logger.DispatchingRtmpStreamUnsubscribedEventError(clientId, ex);
             }
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpServerEventHandlers/RtmpServerConnectionEventHandler.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpServerEventHandlers/RtmpServerConnectionEventHandler.cs
@@ -25,7 +25,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.RtmpServerEventHandlers
 
         public async ValueTask OnRtmpClientDisposedAsync(IEventContext context, IRtmpClientSessionContext clientContext)
         {
-            _mediaMessageBroadcaster.UnregisterClient(clientContext);
+            await _mediaMessageBroadcaster.UnregisterClientAsync(clientContext);
 
             foreach (var streamContext in clientContext.GetStreamContexts())
                 await _streamDeletionService.DeleteStreamAsync(streamContext);

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpStreamContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpStreamContext.cs
@@ -222,7 +222,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
 
         public void CompleteInitialization()
         {
-            _initializationTcs.SetResult();
+            _initializationTcs.TrySetResult();
         }
 
         public Task UntilInitializationCompleteAsync()

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpStreamContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/RtmpStreamContext.cs
@@ -1,6 +1,7 @@
 ﻿using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
 using LiveStreamingServerNet.Utilities.Buffers;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
+using LiveStreamingServerNet.Utilities.Extensions;
 
 namespace LiveStreamingServerNet.Rtmp.Server.Internal
 {
@@ -225,9 +226,9 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal
             _initializationTcs.TrySetResult();
         }
 
-        public Task UntilInitializationCompleteAsync()
+        public Task UntilInitializationCompleteAsync(CancellationToken cancellationToken)
         {
-            return _initializationTask;
+            return _initializationTask.WithCancellation(cancellationToken);
         }
 
         public override void Dispose()

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpCacherService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpCacherService.cs
@@ -3,8 +3,12 @@ using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 
 namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts
 {
-    internal interface IRtmpMediaMessageCacherService : IAsyncDisposable
+    internal interface IRtmpCacherService : IAsyncDisposable
     {
+        ValueTask CacheStreamMetaDataAsync(
+            IRtmpPublishStreamContext publishStreamContext,
+            IReadOnlyDictionary<string, object> metaData);
+
         ValueTask CacheSequenceHeaderAsync(
             IRtmpPublishStreamContext publishStreamContext,
             MediaType mediaType,

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpMediaMessageBroadcasterService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpMediaMessageBroadcasterService.cs
@@ -14,6 +14,6 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts
             IDataBuffer payloadBuffer);
 
         void RegisterClient(IRtmpClientSessionContext clientContext);
-        void UnregisterClient(IRtmpClientSessionContext clientContext);
+        ValueTask UnregisterClientAsync(IRtmpClientSessionContext clientContext);
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpMetaDataProcessorService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpMetaDataProcessorService.cs
@@ -1,0 +1,9 @@
+﻿using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
+
+namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts
+{
+    internal interface IRtmpMetaDataProcessorService
+    {
+        ValueTask<bool> ProcessMetaDataAsync(IRtmpPublishStreamContext publishStreamContext, uint timestamp, IReadOnlyDictionary<string, object> metaData);
+    }
+}

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpStreamManagerService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/Contracts/IRtmpStreamManagerService.cs
@@ -4,12 +4,12 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts
 {
     internal interface IRtmpStreamManagerService
     {
-        PublishingStreamResult StartPublishing(IRtmpStreamContext streamContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments, out IList<IRtmpSubscribeStreamContext> subscribeStreamContexts);
-        PublishingStreamResult StartDirectPublishing(IRtmpPublishStreamContext publishStreamContext, out IList<IRtmpSubscribeStreamContext> subscribeStreamContexts);
-        bool StopPublishing(IRtmpPublishStreamContext publishStreamContext, out IList<IRtmpSubscribeStreamContext> subscribeStreamContexts);
+        ValueTask<(PublishingStreamResult Result, IList<IRtmpSubscribeStreamContext> SubscribeStreamContexts)> StartPublishingAsync(IRtmpStreamContext streamContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments);
+        ValueTask<(PublishingStreamResult Result, IList<IRtmpSubscribeStreamContext> SubscribeStreamContexts)> StartDirectPublishingAsync(IRtmpPublishStreamContext publishStreamContext);
+        ValueTask<(bool Result, IList<IRtmpSubscribeStreamContext> SubscribeStreamContexts)> StopPublishingAsync(IRtmpPublishStreamContext publishStreamContext);
 
-        SubscribingStreamResult StartSubscribing(IRtmpStreamContext streamContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments, out IRtmpPublishStreamContext? publishStreamContext);
-        bool StopSubscribing(IRtmpSubscribeStreamContext subscribeStreamContext);
+        ValueTask<(SubscribingStreamResult Result, IRtmpPublishStreamContext? PublishStreamContext)> StartSubscribingAsync(IRtmpStreamContext streamContext, string streamPath, IReadOnlyDictionary<string, string> streamArguments);
+        ValueTask<bool> StopSubscribingAsync(IRtmpSubscribeStreamContext subscribeStreamContext);
 
         IReadOnlyList<string> GetStreamPaths();
         IRtmpPublishStreamContext? GetPublishStreamContext(string streamPath);

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpAudioDataProcessorService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpAudioDataProcessorService.cs
@@ -11,7 +11,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
     internal class RtmpAudioDataProcessorService : IRtmpAudioDataProcessorService
     {
         private readonly IRtmpStreamManagerService _streamManager;
-        private readonly IRtmpMediaMessageCacherService _mediaMessageCacher;
+        private readonly IRtmpCacherService _cacher;
         private readonly IRtmpMediaMessageBroadcasterService _mediaMessageBroadcaster;
         private readonly ILogger _logger;
 
@@ -19,13 +19,13 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
 
         public RtmpAudioDataProcessorService(
             IRtmpStreamManagerService streamManager,
-            IRtmpMediaMessageCacherService mediaMessageCacher,
+            IRtmpCacherService cacher,
             IRtmpMediaMessageBroadcasterService mediaMessageBroadcaster,
             ILogger<RtmpAudioDataProcessorService> logger,
             IFilter<AudioCodec>? audioCodecFilter = null)
         {
             _streamManager = streamManager;
-            _mediaMessageCacher = mediaMessageCacher;
+            _cacher = cacher;
             _mediaMessageBroadcaster = mediaMessageBroadcaster;
             _logger = logger;
 
@@ -124,11 +124,11 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
 
             if (aacPacketType == AACPacketType.SequenceHeader)
             {
-                await _mediaMessageCacher.CacheSequenceHeaderAsync(publishStreamContext, MediaType.Audio, payloadBuffer);
+                await _cacher.CacheSequenceHeaderAsync(publishStreamContext, MediaType.Audio, payloadBuffer);
             }
             else if (publishStreamContext.GroupOfPicturesCacheActivated)
             {
-                await _mediaMessageCacher.CachePictureAsync(publishStreamContext, MediaType.Audio, payloadBuffer, timestamp);
+                await _cacher.CachePictureAsync(publishStreamContext, MediaType.Audio, payloadBuffer, timestamp);
             }
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMediaCachingInterceptionService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMediaCachingInterceptionService.cs
@@ -2,61 +2,86 @@
 using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
+using LiveStreamingServerNet.Utilities.Common;
+using LiveStreamingServerNet.Utilities.Common.Contracts;
 
 namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
 {
     internal class RtmpMediaCachingInterceptionService : IRtmpMediaCachingInterceptionService
     {
         private readonly IEnumerable<IRtmpMediaCachingInterceptor> _interceptors;
+        private readonly IPool<List<IRtmpMediaCachingInterceptor>> _interceptorListPool;
 
         public RtmpMediaCachingInterceptionService(IEnumerable<IRtmpMediaCachingInterceptor> interceptors)
         {
             _interceptors = interceptors;
+
+            _interceptorListPool = new Pool<List<IRtmpMediaCachingInterceptor>>(
+                () => new List<IRtmpMediaCachingInterceptor>(),
+                obtainCallback: null,
+                recycleCallback: x => x.Clear());
         }
 
         public async ValueTask CachePictureAsync(IRtmpPublishStreamContext publishStreamContext, MediaType mediaType, IDataBuffer payloadBuffer, uint timestamp)
         {
-            if (publishStreamContext.StreamContext == null)
-                return;
-
-            if (!_interceptors.Any())
-                return;
-
-            var rentedBuffer = payloadBuffer.ToRentedBuffer();
+            var streamPath = publishStreamContext.StreamPath;
+            var interceptors = GetFilteredInterceptors(streamPath, mediaType);
 
             try
             {
-                var streamPath = publishStreamContext.StreamPath;
+                if (!interceptors.Any())
+                    return;
 
-                foreach (var interceptor in _interceptors)
-                    await interceptor.OnCachePictureAsync(streamPath, mediaType, rentedBuffer, timestamp);
+                var rentedBuffer = payloadBuffer.ToRentedBuffer();
+
+                try
+                {
+                    foreach (var interceptor in _interceptors)
+                        await interceptor.OnCachePictureAsync(streamPath, mediaType, rentedBuffer, timestamp);
+                }
+                finally
+                {
+                    rentedBuffer.Unclaim();
+                }
             }
             finally
             {
-                rentedBuffer.Unclaim();
+                _interceptorListPool.Recycle(interceptors);
             }
         }
 
         public async ValueTask CacheSequenceHeaderAsync(IRtmpPublishStreamContext publishStreamContext, MediaType mediaType, byte[] sequenceHeader)
         {
-            if (publishStreamContext.StreamContext == null)
-                return;
-
             var streamPath = publishStreamContext.StreamPath;
 
             foreach (var interceptor in _interceptors)
-                await interceptor.OnCacheSequenceHeaderAsync(streamPath, mediaType, sequenceHeader);
+            {
+                if (interceptor.FilterCache(streamPath, mediaType))
+                {
+                    await interceptor.OnCacheSequenceHeaderAsync(streamPath, mediaType, sequenceHeader);
+                }
+            }
         }
 
         public async ValueTask ClearGroupOfPicturesCacheAsync(IRtmpPublishStreamContext publishStreamContext)
         {
-            if (publishStreamContext.StreamContext == null)
-                return;
-
             var streamPath = publishStreamContext.StreamPath;
 
             foreach (var interceptor in _interceptors)
                 await interceptor.OnClearGroupOfPicturesCacheAsync(streamPath);
+        }
+
+        private List<IRtmpMediaCachingInterceptor> GetFilteredInterceptors(string streamPath, MediaType mediaType)
+        {
+            var interceptors = _interceptorListPool.Obtain();
+
+            foreach (var interceptor in _interceptors)
+            {
+                if (interceptor.FilterCache(streamPath, mediaType))
+                    interceptors.Add(interceptor);
+            }
+
+            return interceptors;
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMediaMessageBroadcasterService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMediaMessageBroadcasterService.cs
@@ -179,7 +179,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
                     {
                         if (!subscriptionInitialized)
                         {
-                            await packet.StreamContext.UntilInitializationCompleteAsync();
+                            await packet.StreamContext.UntilInitializationCompleteAsync(cancellation);
                             subscriptionInitialized = true;
                         }
 

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMediaMessageInterceptionService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMediaMessageInterceptionService.cs
@@ -2,39 +2,65 @@
 using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts;
 using LiveStreamingServerNet.Utilities.Buffers.Contracts;
+using LiveStreamingServerNet.Utilities.Common;
+using LiveStreamingServerNet.Utilities.Common.Contracts;
 
 namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
 {
     internal class RtmpMediaMessageInterceptionService : IRtmpMediaMessageInterceptionService
     {
         private readonly IEnumerable<IRtmpMediaMessageInterceptor> _interceptors;
+        private readonly IPool<List<IRtmpMediaMessageInterceptor>> _interceptorListPool;
 
         public RtmpMediaMessageInterceptionService(IEnumerable<IRtmpMediaMessageInterceptor> interceptors)
         {
             _interceptors = interceptors;
+
+            _interceptorListPool = new Pool<List<IRtmpMediaMessageInterceptor>>(
+                () => new List<IRtmpMediaMessageInterceptor>(),
+                obtainCallback: null,
+                recycleCallback: x => x.Clear());
         }
 
         public async ValueTask ReceiveMediaMessageAsync(IRtmpPublishStreamContext publishStreamContext, MediaType mediaType, IDataBuffer payloadBuffer, uint timestamp, bool isSkippable)
         {
-            if (publishStreamContext.StreamContext == null)
-                return;
-
-            if (!_interceptors.Any())
-                return;
-
-            var rentedBuffer = payloadBuffer.ToRentedBuffer();
+            var streamPath = publishStreamContext.StreamPath;
+            var interceptors = GetFilteredInterceptors(streamPath, mediaType, timestamp, isSkippable);
 
             try
             {
-                var streamPath = publishStreamContext.StreamPath;
+                if (!interceptors.Any())
+                    return;
 
-                foreach (var interceptor in _interceptors)
-                    await interceptor.OnReceiveMediaMessageAsync(streamPath, mediaType, rentedBuffer, timestamp, isSkippable);
+                var rentedBuffer = payloadBuffer.ToRentedBuffer();
+
+                try
+                {
+                    foreach (var interceptor in interceptors)
+                        await interceptor.OnReceiveMediaMessageAsync(streamPath, mediaType, rentedBuffer, timestamp, isSkippable);
+                }
+                finally
+                {
+                    rentedBuffer.Unclaim();
+                }
             }
             finally
             {
-                rentedBuffer.Unclaim();
+                _interceptorListPool.Recycle(interceptors);
             }
+        }
+
+        private List<IRtmpMediaMessageInterceptor> GetFilteredInterceptors(string streamPath, MediaType mediaType, uint timestamp, bool isSkippable)
+        {
+            var interceptors = _interceptorListPool.Obtain();
+
+            foreach (var interceptor in _interceptors)
+            {
+                if (interceptor.FilterMediaMessage(streamPath, mediaType, timestamp, isSkippable))
+                    interceptors.Add(interceptor);
+            }
+
+            return interceptors;
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMetaDataProcessorService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpMetaDataProcessorService.cs
@@ -1,0 +1,45 @@
+﻿using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
+using LiveStreamingServerNet.Rtmp.Server.Internal.Services.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
+{
+    internal class RtmpMetaDataProcessorService : IRtmpMetaDataProcessorService
+    {
+        private readonly IRtmpStreamManagerService _streamManager;
+        private readonly IRtmpCacherService _cacher;
+        private readonly ILogger _logger;
+
+        public RtmpMetaDataProcessorService(
+            IRtmpStreamManagerService streamManager,
+            IRtmpCacherService cacher,
+            ILogger<RtmpMetaDataProcessorService> logger)
+        {
+            _streamManager = streamManager;
+            _cacher = cacher;
+            _logger = logger;
+        }
+
+        public async ValueTask<bool> ProcessMetaDataAsync(IRtmpPublishStreamContext publishStreamContext, uint timestamp, IReadOnlyDictionary<string, object> metaData)
+        {
+            await CacheMetaDataAsync(publishStreamContext, metaData);
+            BroadcastMetaDataToSubscribers(publishStreamContext, timestamp);
+            return true;
+        }
+
+        private async Task CacheMetaDataAsync(IRtmpPublishStreamContext publishStreamContext, IReadOnlyDictionary<string, object> metaData)
+        {
+            await _cacher.CacheStreamMetaDataAsync(publishStreamContext, metaData);
+        }
+
+        private void BroadcastMetaDataToSubscribers(IRtmpPublishStreamContext publishStreamContext, uint timestamp)
+        {
+            var subscribeStreamContexts = _streamManager.GetSubscribeStreamContexts(publishStreamContext.StreamPath);
+
+            _cacher.SendCachedStreamMetaDataMessage(
+                subscribeStreamContexts,
+                publishStreamContext,
+                timestamp);
+        }
+    }
+}

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpStreamDeletionService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpStreamDeletionService.cs
@@ -6,14 +6,10 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
     internal class RtmpStreamDeletionService : IRtmpStreamDeletionService
     {
         private readonly IRtmpStreamManagerService _rtmpStreamManager;
-        private readonly IRtmpServerStreamEventDispatcher _eventDispatcher;
 
-        public RtmpStreamDeletionService(
-            IRtmpStreamManagerService rtmpStreamManager,
-            IRtmpServerStreamEventDispatcher eventDispatcher)
+        public RtmpStreamDeletionService(IRtmpStreamManagerService rtmpStreamManager)
         {
             _rtmpStreamManager = rtmpStreamManager;
-            _eventDispatcher = eventDispatcher;
         }
 
         public async ValueTask CloseStreamAsync(IRtmpStreamContext streamContext)
@@ -33,20 +29,20 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
         {
             var publishStreamContext = streamContext.PublishContext;
 
-            if (publishStreamContext == null || !_rtmpStreamManager.StopPublishing(publishStreamContext, out _))
+            if (publishStreamContext == null)
                 return;
 
-            await _eventDispatcher.RtmpStreamUnpublishedAsync(streamContext.ClientContext, publishStreamContext.StreamPath);
+            await _rtmpStreamManager.StopPublishingAsync(publishStreamContext);
         }
 
         private async ValueTask StopSubscribingStreamIfNeededAsync(IRtmpStreamContext streamContext)
         {
             var subscribeStreamContext = streamContext.SubscribeContext;
 
-            if (subscribeStreamContext == null || !_rtmpStreamManager.StopSubscribing(subscribeStreamContext))
+            if (subscribeStreamContext == null)
                 return;
 
-            await _eventDispatcher.RtmpStreamUnsubscribedAsync(streamContext.ClientContext, subscribeStreamContext.StreamPath);
+            await _rtmpStreamManager.StopSubscribingAsync(subscribeStreamContext);
         }
     }
 }

--- a/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpVideoDataProcessorService.cs
+++ b/src/LiveStreamingServerNet.Rtmp.Server/Internal/Services/RtmpVideoDataProcessorService.cs
@@ -13,7 +13,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
     internal class RtmpVideoDataProcessorService : IRtmpVideoDataProcessorService
     {
         private readonly IRtmpStreamManagerService _streamManager;
-        private readonly IRtmpMediaMessageCacherService _mediaMessageCacher;
+        private readonly IRtmpCacherService _cacher;
         private readonly IRtmpMediaMessageBroadcasterService _mediaMessageBroadcaster;
         private readonly RtmpServerConfiguration _config;
         private readonly ILogger _logger;
@@ -22,14 +22,14 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
 
         public RtmpVideoDataProcessorService(
             IRtmpStreamManagerService streamManager,
-            IRtmpMediaMessageCacherService mediaMessageCacher,
+            IRtmpCacherService cacher,
             IRtmpMediaMessageBroadcasterService mediaMessageBroadcaster,
             IOptions<RtmpServerConfiguration> config,
             ILogger<RtmpVideoDataProcessorService> logger,
             IFilter<VideoCodec>? videoCodecFilter = null)
         {
             _streamManager = streamManager;
-            _mediaMessageCacher = mediaMessageCacher;
+            _cacher = cacher;
             _mediaMessageBroadcaster = mediaMessageBroadcaster;
             _config = config.Value;
             _logger = logger;
@@ -208,22 +208,22 @@ namespace LiveStreamingServerNet.Rtmp.Server.Internal.Services
 
                 if (publishStreamContext.GroupOfPicturesCacheActivated && frameType == VideoFrameType.KeyFrame)
                 {
-                    await _mediaMessageCacher.ClearGroupOfPicturesCacheAsync(publishStreamContext);
+                    await _cacher.ClearGroupOfPicturesCacheAsync(publishStreamContext);
                 }
 
                 if (frameType == VideoFrameType.KeyFrame && avcPacketType == AVCPacketType.SequenceHeader)
                 {
-                    await _mediaMessageCacher.CacheSequenceHeaderAsync(publishStreamContext, MediaType.Video, payloadBuffer);
+                    await _cacher.CacheSequenceHeaderAsync(publishStreamContext, MediaType.Video, payloadBuffer);
                 }
                 else if (publishStreamContext.GroupOfPicturesCacheActivated && avcPacketType == AVCPacketType.NALU)
                 {
-                    await _mediaMessageCacher.CachePictureAsync(publishStreamContext, MediaType.Video, payloadBuffer, timestamp);
+                    await _cacher.CachePictureAsync(publishStreamContext, MediaType.Video, payloadBuffer, timestamp);
                 }
             }
             else if (publishStreamContext.GroupOfPicturesCacheActivated)
             {
                 publishStreamContext.GroupOfPicturesCacheActivated = false;
-                await _mediaMessageCacher.ClearGroupOfPicturesCacheAsync(publishStreamContext);
+                await _cacher.ClearGroupOfPicturesCacheAsync(publishStreamContext);
             }
         }
     }

--- a/src/LiveStreamingServerNet.Rtmp/Internal/Contracts/IRtmpChunkStreamContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/Contracts/IRtmpChunkStreamContext.cs
@@ -8,8 +8,11 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Contracts
         int ChunkType { get; set; }
         bool IsFirstChunkOfMessage { get; }
         IRtmpChunkMessageHeaderContext MessageHeader { get; }
-        IDataBuffer? PayloadBuffer { get; set; }
+        IDataBuffer? PayloadBuffer { get; }
         uint Timestamp { get; set; }
+
+        void AssignPayload(IDataBufferPool dataBufferPool);
+        void RecyclePayload(IDataBufferPool dataBufferPool);
     }
 
     internal interface IRtmpChunkMessageHeaderContext

--- a/src/LiveStreamingServerNet.Rtmp/Internal/RtmpChunkStreamContext.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/RtmpChunkStreamContext.cs
@@ -9,13 +9,30 @@ namespace LiveStreamingServerNet.Rtmp.Internal
         public int ChunkType { get; set; }
         public bool IsFirstChunkOfMessage => PayloadBuffer == null;
         public IRtmpChunkMessageHeaderContext MessageHeader { get; }
-        public IDataBuffer? PayloadBuffer { get; set; }
+        public IDataBuffer? PayloadBuffer { get; private set; }
         public uint Timestamp { get; set; }
 
         public RtmpChunkStreamContext(uint chunkStreamId)
         {
             ChunkStreamId = chunkStreamId;
             MessageHeader = new RtmpChunkMessageHeaderContext();
+        }
+
+        public void AssignPayload(IDataBufferPool dataBufferPool)
+        {
+            if (PayloadBuffer != null)
+                return;
+
+            PayloadBuffer = dataBufferPool.Obtain();
+        }
+
+        public void RecyclePayload(IDataBufferPool dataBufferPool)
+        {
+            if (PayloadBuffer == null)
+                return;
+
+            dataBufferPool.Recycle(PayloadBuffer);
+            PayloadBuffer = null;
         }
     }
 

--- a/src/LiveStreamingServerNet.Rtmp/Internal/Services/RtmpChunkMessageAggregatorService.cs
+++ b/src/LiveStreamingServerNet.Rtmp/Internal/Services/RtmpChunkMessageAggregatorService.cs
@@ -165,7 +165,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Services
         {
             if (chunkStreamContext.IsFirstChunkOfMessage)
             {
-                chunkStreamContext.PayloadBuffer = _dataBufferPool.Obtain();
+                chunkStreamContext.AssignPayload(_dataBufferPool);
             }
 
             var payloadBuffer = chunkStreamContext.PayloadBuffer!;
@@ -193,11 +193,7 @@ namespace LiveStreamingServerNet.Rtmp.Internal.Services
 
         public void ResetChunkStreamContext(IRtmpChunkStreamContext chunkStreamContext)
         {
-            if (chunkStreamContext.PayloadBuffer == null)
-                return;
-
-            _dataBufferPool.Recycle(chunkStreamContext.PayloadBuffer);
-            chunkStreamContext.PayloadBuffer = null;
+            chunkStreamContext.RecyclePayload(_dataBufferPool);
         }
     }
 }

--- a/src/LiveStreamingServerNet.Utilities/Buffers/BufferCache.cs
+++ b/src/LiveStreamingServerNet.Utilities/Buffers/BufferCache.cs
@@ -95,10 +95,16 @@ namespace LiveStreamingServerNet.Utilities.Buffers
 
         public void Dispose()
         {
-            if (_bufferPool != null)
-                _bufferPool.Return(_buffer);
-            else
-                ArrayPool<byte>.Shared.Return(_buffer);
+            lock (_syncLock)
+            {
+                if (_bufferPool != null)
+                    _bufferPool.Return(_buffer);
+                else
+                    ArrayPool<byte>.Shared.Return(_buffer);
+
+                Reset();
+                _buffer = null!;
+            }
         }
 
         private record struct BufferInfoWithSize(TBufferInfo Info, int Size);

--- a/src/LiveStreamingServerNet.Utilities/Extensions/TaskExtensions.cs
+++ b/src/LiveStreamingServerNet.Utilities/Extensions/TaskExtensions.cs
@@ -8,9 +8,13 @@
 
             try
             {
-                await Task.WhenAny(task, Task.Delay(Timeout.Infinite, cts.Token));
+                var completedTask = await Task.WhenAny(task, Task.Delay(Timeout.Infinite, cts.Token));
+                await completedTask;
             }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested) { }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                throw;
+            }
             finally
             {
                 cts.Cancel();

--- a/src/LiveStreamingServerNet.Utilities/Extensions/TaskExtensions.cs
+++ b/src/LiveStreamingServerNet.Utilities/Extensions/TaskExtensions.cs
@@ -11,10 +11,6 @@
                 var completedTask = await Task.WhenAny(task, Task.Delay(Timeout.Infinite, cts.Token));
                 await completedTask;
             }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested)
-            {
-                throw;
-            }
             finally
             {
                 cts.Cancel();

--- a/test/LiveStreamingServerNet.Flv.Test/FlvClient.Test.cs
+++ b/test/LiveStreamingServerNet.Flv.Test/FlvClient.Test.cs
@@ -85,7 +85,7 @@ namespace LiveStreamingServerNet.Flv.Test
             await _sut.DisposeAsync();
 
             // Assert
-            _mediaTagBroadcaster.Received(1).UnregisterClient(_sut);
+            _ = _mediaTagBroadcaster.Received(1).UnregisterClientAsync(_sut);
         }
 
         [Fact]

--- a/test/LiveStreamingServerNet.Flv.Test/Services/FlvClientHandler.Test.cs
+++ b/test/LiveStreamingServerNet.Flv.Test/Services/FlvClientHandler.Test.cs
@@ -54,7 +54,7 @@ namespace LiveStreamingServerNet.Flv.Test.Services
             _streamContext.VideoSequenceHeader.Returns(videoSequenceHeader);
 
             // Act
-            await _sut.RunClientAsync(_client);
+            await _sut.RunClientAsync(_client, default);
 
             // Assert
             Received.InOrder(() =>
@@ -71,10 +71,10 @@ namespace LiveStreamingServerNet.Flv.Test.Services
         public async Task RunClientAsync_Should_Stop_After_ClientIsComplete()
         {
             // Arrange
-            _client.UntilCompleteAsync().Returns(Task.CompletedTask);
+            _client.UntilCompleteAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
             // Act
-            await _sut.RunClientAsync(_client);
+            await _sut.RunClientAsync(_client, default);
 
             // Assert
             _streamManager.Received().StopSubscribingStream(_client);

--- a/test/LiveStreamingServerNet.Flv.Test/Services/FlvClientHandler.Test.cs
+++ b/test/LiveStreamingServerNet.Flv.Test/Services/FlvClientHandler.Test.cs
@@ -1,7 +1,10 @@
 ﻿using AutoFixture;
+using LiveStreamingServerNet.Flv.Configurations;
 using LiveStreamingServerNet.Flv.Internal.Contracts;
 using LiveStreamingServerNet.Flv.Internal.Services;
 using LiveStreamingServerNet.Flv.Internal.Services.Contracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace LiveStreamingServerNet.Flv.Test.Services
@@ -11,6 +14,8 @@ namespace LiveStreamingServerNet.Flv.Test.Services
         private readonly IFixture _fixture;
         private readonly IFlvStreamManagerService _streamManager;
         private readonly IFlvMediaTagCacherService _mediaTagCacher;
+        private readonly MediaStreamingConfiguration _config;
+        private readonly ILogger<FlvClientHandler> _logger;
         private readonly string _streamPath;
         private readonly IFlvClient _client;
         private readonly IFlvStreamContext _streamContext;
@@ -21,6 +26,8 @@ namespace LiveStreamingServerNet.Flv.Test.Services
             _fixture = new Fixture();
             _streamManager = Substitute.For<IFlvStreamManagerService>();
             _mediaTagCacher = Substitute.For<IFlvMediaTagCacherService>();
+            _config = new MediaStreamingConfiguration();
+            _logger = Substitute.For<ILogger<FlvClientHandler>>();
 
             _streamPath = _fixture.Create<string>();
             _client = Substitute.For<IFlvClient>();
@@ -29,7 +36,7 @@ namespace LiveStreamingServerNet.Flv.Test.Services
             _streamContext = Substitute.For<IFlvStreamContext>();
             _streamManager.GetFlvStreamContext(_client.StreamPath).Returns(_streamContext);
 
-            _sut = new FlvClientHandler(_streamManager, _mediaTagCacher);
+            _sut = new FlvClientHandler(_streamManager, _mediaTagCacher, Options.Create(_config), _logger);
         }
 
         [Theory]

--- a/test/LiveStreamingServerNet.Flv.Test/Services/FlvMediaTagBroadcasterService.Test.cs
+++ b/test/LiveStreamingServerNet.Flv.Test/Services/FlvMediaTagBroadcasterService.Test.cs
@@ -83,7 +83,7 @@ namespace LiveStreamingServerNet.Flv.Test.Services
 
             Received.InOrder(() =>
             {
-                client.Received(1).UntilInitializationCompleteAsync();
+                client.Received(1).UntilInitializationCompleteAsync(Arg.Any<CancellationToken>());
                 _mediaTagSender.When(x => x.SendMediaTagAsync(
                     client, mediaType, rentedBuffer.Buffer, rentedBuffer.Size, timestamp, Arg.Any<CancellationToken>()));
             });

--- a/test/LiveStreamingServerNet.Flv.Test/Services/FlvStreamManagerService.Test.cs
+++ b/test/LiveStreamingServerNet.Flv.Test/Services/FlvStreamManagerService.Test.cs
@@ -131,7 +131,7 @@ namespace LiveStreamingServerNet.Flv.Test.Services
             sut.StartPublishingStream(streamContext);
 
             // Act
-            var result = sut.StartSubscribingStream(flvClient, streamPath);
+            var result = sut.StartSubscribingStream(flvClient, streamPath, true);
 
             // Assert
             result.Should().Be(SubscribingStreamResult.Succeeded);
@@ -150,10 +150,10 @@ namespace LiveStreamingServerNet.Flv.Test.Services
 
             var sut = new FlvStreamManagerService();
             sut.StartPublishingStream(streamContext);
-            sut.StartSubscribingStream(flvClient, streamPath);
+            sut.StartSubscribingStream(flvClient, streamPath, true);
 
             // Act
-            var result = sut.StartSubscribingStream(flvClient, streamPath);
+            var result = sut.StartSubscribingStream(flvClient, streamPath, true);
 
             // Assert
             result.Should().Be(SubscribingStreamResult.AlreadySubscribing);
@@ -171,7 +171,7 @@ namespace LiveStreamingServerNet.Flv.Test.Services
 
             var sut = new FlvStreamManagerService();
             sut.StartPublishingStream(streamContext);
-            sut.StartSubscribingStream(flvClient, streamPath);
+            sut.StartSubscribingStream(flvClient, streamPath, true);
 
             // Act
             var result = sut.StopSubscribingStream(flvClient);
@@ -209,8 +209,8 @@ namespace LiveStreamingServerNet.Flv.Test.Services
 
             var sut = new FlvStreamManagerService();
             sut.StartPublishingStream(streamContext);
-            sut.StartSubscribingStream(flvClient1, streamPath);
-            sut.StartSubscribingStream(flvClient2, streamPath);
+            sut.StartSubscribingStream(flvClient1, streamPath, true);
+            sut.StartSubscribingStream(flvClient2, streamPath, true);
 
             // Act
             var result = sut.GetSubscribers(streamPath);
@@ -235,8 +235,8 @@ namespace LiveStreamingServerNet.Flv.Test.Services
 
             var sut = new FlvStreamManagerService();
             sut.StartPublishingStream(streamContext);
-            sut.StartSubscribingStream(flvClient1, streamPath);
-            sut.StartSubscribingStream(flvClient2, streamPath);
+            sut.StartSubscribingStream(flvClient1, streamPath, true);
+            sut.StartSubscribingStream(flvClient2, streamPath, true);
 
             // Act
             var result = sut.StopPublishingStream(streamPath, out var existingSubscribers);

--- a/test/LiveStreamingServerNet.Networking.Server.Test/ClientSessionManager.Test.cs
+++ b/test/LiveStreamingServerNet.Networking.Server.Test/ClientSessionManager.Test.cs
@@ -59,8 +59,8 @@ namespace LiveStreamingServerNet.Networking.Server.Test
         public async Task AcceptClientAsync_Should_DispatchServerEvents_When_TcpClientIsAccepted()
         {
             // Arrange
-            var clientTcs = new TaskCompletionSource();
-            _clientSession.RunAsync(Arg.Any<CancellationToken>()).Returns(clientTcs.Task);
+            using var cts = new CancellationTokenSource();
+            _clientSession.RunAsync(Arg.Any<CancellationToken>()).Returns(Task.Delay(Timeout.InfiniteTimeSpan, cts.Token));
 
             var tcs = new TaskCompletionSource();
             _eventDispatcher.When(x => x.ClientDisconnectedAsync(_clientSession)).Do(x => tcs.SetResult());
@@ -76,9 +76,9 @@ namespace LiveStreamingServerNet.Networking.Server.Test
             });
 
             // Act
-            clientTcs.SetCanceled();
+            cts.Cancel();
 
-            await _sut.WaitUntilAllClientTasksCompleteAsync(default);
+            await _sut.WaitUntilAllClientTasksCompleteAsync(cts.Token);
             await tcs.Task;
 
             // Assert

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/RtmpClientSessionHandler.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/RtmpClientSessionHandler.Test.cs
@@ -5,6 +5,7 @@ using LiveStreamingServerNet.Rtmp.Server.Internal;
 using LiveStreamingServerNet.Rtmp.Server.Internal.Contracts;
 using LiveStreamingServerNet.Rtmp.Server.Internal.RtmpEvents;
 using LiveStreamingServerNet.Rtmp.Server.RateLimiting.Contracts;
+using LiveStreamingServerNet.Utilities.Buffers.Contracts;
 using LiveStreamingServerNet.Utilities.Mediators.Contracts;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -14,6 +15,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test
     public class RtmpClientSessionHandlerTest : IAsyncDisposable
     {
         private readonly IMediator _mediator;
+        private readonly IDataBufferPool _dataBufferPool;
         private readonly IRtmpServerConnectionEventDispatcher _eventDispatcher;
         private readonly ILogger<RtmpClientSessionHandler> _logger;
         private readonly IRtmpClientSessionContext _clientContext;
@@ -25,6 +27,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test
         public RtmpClientSessionHandlerTest()
         {
             _mediator = Substitute.For<IMediator>();
+            _dataBufferPool = Substitute.For<IDataBufferPool>();
             _eventDispatcher = Substitute.For<IRtmpServerConnectionEventDispatcher>();
             _logger = Substitute.For<ILogger<RtmpClientSessionHandler>>();
 
@@ -38,7 +41,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test
 
             _networkStream = Substitute.For<INetworkStream>();
 
-            _sut = new RtmpClientSessionHandler(_clientContext, _mediator, _eventDispatcher, _logger, _bandwidthLimiterFactory);
+            _sut = new RtmpClientSessionHandler(_clientContext, _mediator, _dataBufferPool, _eventDispatcher, _logger, _bandwidthLimiterFactory);
         }
 
         public async ValueTask DisposeAsync()

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/RtmpEventHandlers/Commands/RtmpPlayCommandHandler.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/RtmpEventHandlers/Commands/RtmpPlayCommandHandler.Test.cs
@@ -20,7 +20,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Commands
         private readonly IRtmpStreamManagerService _streamManager;
         private readonly IRtmpCommandMessageSenderService _commandMessageSender;
         private readonly IRtmpUserControlMessageSenderService _userControlMessageSender;
-        private readonly IRtmpMediaMessageCacherService _mediaMessageCacher;
+        private readonly IRtmpCacherService _cacher;
         private readonly IStreamAuthorization _streamAuthorization;
         private readonly IRtmpStreamContext _streamContext;
         private readonly IRtmpSubscribeStreamContext _subscribeStreamContext;
@@ -36,7 +36,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Commands
             _streamManager = Substitute.For<IRtmpStreamManagerService>();
             _commandMessageSender = Substitute.For<IRtmpCommandMessageSenderService>();
             _userControlMessageSender = Substitute.For<IRtmpUserControlMessageSenderService>();
-            _mediaMessageCacher = Substitute.For<IRtmpMediaMessageCacherService>();
+            _cacher = Substitute.For<IRtmpCacherService>();
             _streamAuthorization = Substitute.For<IStreamAuthorization>();
             _streamContext = Substitute.For<IRtmpStreamContext>();
             _subscribeStreamContext = Substitute.For<IRtmpSubscribeStreamContext>();
@@ -56,7 +56,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Commands
                 _streamManager,
                 _commandMessageSender,
                 _userControlMessageSender,
-                _mediaMessageCacher,
+                _cacher,
                 _streamAuthorization,
                 _logger
             );
@@ -162,14 +162,14 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Commands
             {
                 if (publishStreamExists)
                 {
-                    _mediaMessageCacher.Received(1).SendCachedStreamMetaDataMessage(
+                    _cacher.Received(1).SendCachedStreamMetaDataMessage(
                         _subscribeStreamContext, _publishStreamContext, timestamp);
 
-                    _mediaMessageCacher.Received(1).SendCachedHeaderMessages(
+                    _cacher.Received(1).SendCachedHeaderMessages(
                         _subscribeStreamContext, _publishStreamContext);
 
                     if (gopCacheActivated)
-                        _mediaMessageCacher.Received(1).SendCachedGroupOfPictures(
+                        _cacher.Received(1).SendCachedGroupOfPictures(
                             _subscribeStreamContext, _publishStreamContext);
                 }
 

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpAudioDataProcessorService.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpAudioDataProcessorService.Test.cs
@@ -16,7 +16,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
         private readonly IFixture _fixture;
         private readonly IRtmpClientSessionContext _clientContext;
         private readonly IRtmpStreamManagerService _streamManager;
-        private readonly IRtmpMediaMessageCacherService _mediaMessageCacher;
+        private readonly IRtmpCacherService _cacher;
         private readonly IRtmpMediaMessageBroadcasterService _mediaMessageBroadcaster;
         private readonly ILogger<RtmpAudioDataProcessorService> _logger;
         private readonly IDataBuffer _dataBuffer;
@@ -27,7 +27,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
             _fixture = new Fixture();
             _clientContext = Substitute.For<IRtmpClientSessionContext>();
             _streamManager = Substitute.For<IRtmpStreamManagerService>();
-            _mediaMessageCacher = Substitute.For<IRtmpMediaMessageCacherService>();
+            _cacher = Substitute.For<IRtmpCacherService>();
             _mediaMessageBroadcaster = Substitute.For<IRtmpMediaMessageBroadcasterService>();
             _logger = Substitute.For<ILogger<RtmpAudioDataProcessorService>>();
 
@@ -35,7 +35,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
 
             _sut = new RtmpAudioDataProcessorService(
                 _streamManager,
-                _mediaMessageCacher,
+                _cacher,
                 _mediaMessageBroadcaster,
                 _logger);
         }
@@ -98,10 +98,10 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
             // Assert
             result.Should().BeTrue();
 
-            _ = _mediaMessageCacher.Received(hasHeader ? 1 : 0)
+            _ = _cacher.Received(hasHeader ? 1 : 0)
                 .CacheSequenceHeaderAsync(publisher_publishStreamContext, MediaType.Audio, _dataBuffer);
 
-            _ = _mediaMessageCacher.Received(gopCacheActivated && isPictureCachable ? 1 : 0)
+            _ = _cacher.Received(gopCacheActivated && isPictureCachable ? 1 : 0)
                 .CachePictureAsync(publisher_publishStreamContext, MediaType.Audio, _dataBuffer, timestamp);
 
             publisher_publishStreamContext.Received(1).UpdateTimestamp(timestamp, MediaType.Audio);

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpMediaCachingInterceptionService.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpMediaCachingInterceptionService.Test.cs
@@ -32,6 +32,9 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.Services
             var interceptor1 = Substitute.For<IRtmpMediaCachingInterceptor>();
             var interceptor2 = Substitute.For<IRtmpMediaCachingInterceptor>();
 
+            interceptor1.FilterCache(streamPath, mediaType).Returns(true);
+            interceptor2.FilterCache(streamPath, mediaType).Returns(true);
+
             var interceptors = new List<IRtmpMediaCachingInterceptor> { interceptor1, interceptor2 };
 
             var sut = new RtmpMediaCachingInterceptionService(interceptors);
@@ -57,6 +60,9 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.Services
 
             var interceptor1 = Substitute.For<IRtmpMediaCachingInterceptor>();
             var interceptor2 = Substitute.For<IRtmpMediaCachingInterceptor>();
+
+            interceptor1.FilterCache(streamPath, mediaType).Returns(true);
+            interceptor2.FilterCache(streamPath, mediaType).Returns(true);
 
             var interceptors = new List<IRtmpMediaCachingInterceptor> { interceptor1, interceptor2 };
 

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpMediaMessageBroadcasterService.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpMediaMessageBroadcasterService.Test.cs
@@ -93,7 +93,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.Services
 
             Received.InOrder(() =>
             {
-                subscriber_subscribeStreamContext.Received(1).UntilInitializationCompleteAsync();
+                subscriber_subscribeStreamContext.Received(1).UntilInitializationCompleteAsync(Arg.Any<CancellationToken>());
                 subscriber.Received(1).SendAsync(Arg.Any<IRentedBuffer>());
             });
         }

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpMediaMessageInterceptionService.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpMediaMessageInterceptionService.Test.cs
@@ -33,6 +33,9 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.Services
             var interceptor1 = Substitute.For<IRtmpMediaMessageInterceptor>();
             var interceptor2 = Substitute.For<IRtmpMediaMessageInterceptor>();
 
+            interceptor1.FilterMediaMessage(streamPath, mediaType, timestamp, isSkippable).Returns(true);
+            interceptor2.FilterMediaMessage(streamPath, mediaType, timestamp, isSkippable).Returns(true);
+
             var interceptors = new List<IRtmpMediaMessageInterceptor> { interceptor1, interceptor2 };
 
             var service = new RtmpMediaMessageInterceptionService(interceptors);

--- a/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpVideoDataProcessorService.Test.cs
+++ b/test/LiveStreamingServerNet.Rtmp.Server.Test/Services/RtmpVideoDataProcessorService.Test.cs
@@ -18,7 +18,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
         private readonly IFixture _fixture;
         private readonly IRtmpClientSessionContext _clientContext;
         private readonly IRtmpStreamManagerService _streamManager;
-        private readonly IRtmpMediaMessageCacherService _mediaMessageCacher;
+        private readonly IRtmpCacherService _cacher;
         private readonly IRtmpMediaMessageBroadcasterService _mediaMessageBroadcaster;
         private readonly RtmpServerConfiguration _config;
         private readonly ILogger<RtmpVideoDataProcessorService> _logger;
@@ -30,7 +30,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
             _fixture = new Fixture();
             _clientContext = Substitute.For<IRtmpClientSessionContext>();
             _streamManager = Substitute.For<IRtmpStreamManagerService>();
-            _mediaMessageCacher = Substitute.For<IRtmpMediaMessageCacherService>();
+            _cacher = Substitute.For<IRtmpCacherService>();
             _mediaMessageBroadcaster = Substitute.For<IRtmpMediaMessageBroadcasterService>();
             _config = new RtmpServerConfiguration();
             _logger = Substitute.For<ILogger<RtmpVideoDataProcessorService>>();
@@ -39,7 +39,7 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
 
             _sut = new RtmpVideoDataProcessorService(
                 _streamManager,
-                _mediaMessageCacher,
+                _cacher,
                 _mediaMessageBroadcaster,
                 Options.Create(_config),
                 _logger);
@@ -112,12 +112,12 @@ namespace LiveStreamingServerNet.Rtmp.Server.Test.RtmpEventHandlers.Media
             result.Should().BeTrue();
 
             if (gopCacheActivated && frameType == VideoFrameType.KeyFrame)
-                _ = _mediaMessageCacher.Received(1).ClearGroupOfPicturesCacheAsync(publisher_publishStreamContext);
+                _ = _cacher.Received(1).ClearGroupOfPicturesCacheAsync(publisher_publishStreamContext);
 
-            _ = _mediaMessageCacher.Received(hasHeader ? 1 : 0)
+            _ = _cacher.Received(hasHeader ? 1 : 0)
                 .CacheSequenceHeaderAsync(publisher_publishStreamContext, MediaType.Video, _dataBuffer);
 
-            _ = _mediaMessageCacher.Received(gopCacheActivated && isPictureCachable ? 1 : 0)
+            _ = _cacher.Received(gopCacheActivated && isPictureCachable ? 1 : 0)
                 .CachePictureAsync(publisher_publishStreamContext, MediaType.Video, _dataBuffer, timestamp);
 
             publisher_publishStreamContext.Received(1).UpdateTimestamp(timestamp, MediaType.Video);


### PR DESCRIPTION
#### Summary
- Added support for RTMP relay triggering on FLV requests.
- Added the `LiveStreamingServerNet.FlvRelayDemo` project.
- Added `IRtmpRelayManager` to actively pull RTMP streams from the origin server.
- Fixed buffer recycling issues during client disconnection to reduce memory allocation