### PR TITLE
Fixed complex filters causing ffmpeg to crash because of a malformed collection end

### DIFF
--- a/src/LiveStreamingServerNet.StreamProcessor/Internal/Hls/AdaptiveTranscoding/AdaptiveHlsTranscoder.Arguments.cs
+++ b/src/LiveStreamingServerNet.StreamProcessor/Internal/Hls/AdaptiveTranscoding/AdaptiveHlsTranscoder.Arguments.cs
@@ -141,7 +141,7 @@ namespace LiveStreamingServerNet.StreamProcessor.Internal.Hls.AdaptiveTranscodin
             AppendAudioSplit(downsamplingFilters, sb, audioSrc);
             AppendAudioFilters(downsamplingFilters, sb);
 
-            return sb.ToString();
+            return sb.ToString().TrimEnd(';');
 
             void AppendAdditionalFilters(StringBuilder sb)
             {


### PR DESCRIPTION
When running a project which uses this library on linux (debian 12) and enabling adaptive hls transcoding, the default ffmpeg binary crashes because the complex filters string is malformed. It does work on windows though.

Logs:

```
streamer    | 11.04.25 13:19:52 INFO LiveStreamingServerNet.StreamProcessor.Internal.Hls.AdaptiveTranscoding.AdaptiveHlsTranscoder: Starting FFmpeg process (Arguments=-i rtmp://localhost:1935/live/1?code=52556E4C6B746578316B6743395873456B6E6830425649744A553234796E38397A396868624769554747424534525854535361536B537A776937673558517634 -threads 1 -max_muxing_queue_size 1024 -filter_complex "[0:v]split=2[vout0-0][vout1-0];[vout0-0]scale=-2:720[vout0-1];[vout1-0]scale=-2:180[vout1-1];[0:a]asplit=2[aout0-0][aout1-0];" -c:v libx264 -preset ultrafast -tune zerolatency -crf 23 -g 30 -c:a aac -map "[vout0-1]" -maxrate:v:0 3000k -map "[aout0-0]" -b:a:0 256k -map "[vout1-1]" -maxrate:v:1 200k -map "[aout1-0]" -b:a:1 24k -f hls -hls_list_size 20 -hls_time 1 -hls_flags independent_segments+delete_segments -var_stream_map "v:0,a:0,name:720p v:1,a:1,name:180p" -master_pl_name output.m3u8 storage/cache/hls/1/output_%v.m3u8)

streamer    | [AVFilterGraph @ 0x56230d154880] No such filter: ''
streamer    | Error initializing complex filters.
streamer    | Invalid argument
```